### PR TITLE
Fix deploy and remove actions for multiple functions. Add tests

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const _ = require('lodash');
 const BbPromise = require('bluebird');
 const Api = require('kubernetes-client');
 const helpers = require('../lib/helpers');
+const path = require('path');
 
 class KubelessDeploy {
   constructor(serverless, options) {
@@ -19,31 +21,16 @@ class KubelessDeploy {
 
   validate() {
     helpers.validateEnv();
+    const unsupportedOptions = ['stage', 'region'];
+    helpers.warnUnsupportedOptions(
+      unsupportedOptions,
+      this.options,
+      this.serverless.cli.log.bind(this.serverless.cli)
+    );
     return BbPromise.resolve();
   }
 
-  deployFunction() {
-    const f = this.serverless.service.service;
-    this.serverless.cli.log(`Deploying function: ${f}...`);
-    const funcs = {
-      apiVersion: 'k8s.io/v1',
-      kind: 'Function',
-      metadata: {
-        name: this.serverless.service.service,
-        namespace: 'default',
-      },
-      spec: {
-        deps: '',
-        function: this.serverless.utils.readFileSync(
-          `${this.serverless.service.functions[f].handler.toString().split('.')[0]}.py`
-        ),
-        handler: this.serverless.service.functions[f].handler,
-        runtime: this.serverless.service.provider.runtime,
-        topic: '',
-        type: 'HTTP',
-      },
-    };
-
+  deployFunction(cwd) {
     const thirdPartyResources = new Api.ThirdPartyResources(
       Object.assign(helpers.getMinikubeCredentials(), {
         url: process.env.KUBE_API_URL,
@@ -52,9 +39,63 @@ class KubelessDeploy {
     );
 
     thirdPartyResources.addResource('functions');
-    // Create function
-    thirdPartyResources.ns.functions.post({ body: funcs }, helpers.print);
-    return BbPromise.resolve();
+    const errors = [];
+    let counter = 0;
+    return new BbPromise((resolve, reject) => {
+      _.each(this.serverless.service.functions, (description, name) => {
+        this.serverless.cli.log(`Deploying function: ${name}...`);
+        const funcs = {
+          apiVersion: 'k8s.io/v1',
+          kind: 'Function',
+          metadata: {
+            name,
+            namespace: 'default',
+          },
+          spec: {
+            deps: '',
+            function: this.serverless.utils.readFileSync(
+              path.join(cwd || process.cwd(), `${description.handler.toString().split('.')[0]}.py`)
+            ),
+            handler: description.handler,
+            runtime: this.serverless.service.provider.runtime,
+            topic: '',
+            type: 'HTTP',
+          },
+        };
+        // Create function
+        thirdPartyResources.ns.functions.post({ body: funcs }, (err) => {
+          if (err) {
+            if (err.code === 409) {
+              this.serverless.cli.log(
+                `The function ${name} is already deployed. ` +
+                'Remove it if you want to deploy it again.'
+              );
+            } else {
+              errors.push(
+                `Unable to deploy the function ${name}. Received:\n` +
+                `  Code: ${err.code}\n` +
+                `  Message: ${err.message}`
+              );
+            }
+          } else {
+            this.serverless.cli.log(
+              `Function ${name} succesfully deployed`
+            );
+          }
+          counter++;
+          if (counter === _.keys(this.serverless.service.functions).length) {
+            if (_.isEmpty(errors)) {
+              resolve();
+            } else {
+              reject(
+                `Found errors while deploying the given functions:\n${
+                errors.join('\n')}`
+              );
+            }
+          }
+        });
+      });
+    });
   }
 }
 

--- a/remove/kubelessRemove.js
+++ b/remove/kubelessRemove.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const Api = require('kubernetes-client');
 const BbPromise = require('bluebird');
 const helpers = require('../lib/helpers');
@@ -19,24 +20,61 @@ class KubelessRemove {
 
   validate() {
     helpers.validateEnv();
+    const unsupportedOptions = ['stage', 'region'];
+    helpers.warnUnsupportedOptions(
+      unsupportedOptions,
+      this.options,
+      this.serverless.cli.log.bind(this.serverless.cli)
+    );
     return BbPromise.resolve();
   }
 
   removeFunction() {
-    const f = this.serverless.service.service;
-    this.serverless.cli.log(`Removing function: ${f}...`);
-
     const thirdPartyResources = new Api.ThirdPartyResources(
       Object.assign(helpers.getMinikubeCredentials(), {
         url: process.env.KUBE_API_URL,
         group: 'k8s.io',
       })
     );
-
     thirdPartyResources.addResource('functions');
-    // Delete function
-    thirdPartyResources.ns.functions.delete(f, helpers.print);
-    return BbPromise.resolve();
+
+    const errors = [];
+    let counter = 0;
+    return new BbPromise((resolve, reject) => {
+      _.each(_.keys(this.serverless.service.functions), f => {
+        this.serverless.cli.log(`Removing function: ${f}...`);
+        // Delete function
+        thirdPartyResources.ns.functions.delete(f, (err) => {
+          if (err) {
+            if (err.code === 404) {
+              this.serverless.cli.log(
+                `The function ${f} doesn't exist. ` +
+                'Skipping removal.'
+              );
+            } else {
+              errors.push(
+                `Unable to remove the function ${f}. Received:\n` +
+                `  Code: ${err.code}\n` +
+                `  Message: ${err.message}`
+              );
+            }
+          } else {
+            this.serverless.cli.log(`Function ${f} succesfully deleted`);
+          }
+          counter++;
+          if (counter === _.keys(this.serverless.service.functions).length) {
+            if (_.isEmpty(errors)) {
+              resolve();
+            } else {
+              reject(
+                'Found errors while removing the given functions:\n' +
+                `${errors.join('\n')}`
+              );
+            }
+          }
+        });
+      });
+    });
   }
 }
 

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const _ = require('lodash');
+const Api = require('kubernetes-client');
+const BbPromise = require('bluebird');
+const chaiAsPromised = require('chai-as-promised');
+const expect = require('chai').expect;
+const helpers = require('../lib/helpers');
+const fs = require('fs');
+const moment = require('moment');
+const os = require('os');
+const path = require('path');
+const sinon = require('sinon');
+
+const KubelessDeploy = require('../deploy/kubelessDeploy');
+const serverless = require('./lib/serverless');
+
+require('chai').use(chaiAsPromised);
+
+function rm(p) {
+  if (fs.existsSync(p)) {
+    fs.readdirSync(p).forEach((file) => {
+      const curPath = `${p}/${file}`;
+      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+        rm(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(p);
+  }
+}
+
+describe('KubelessDeploy', () => {
+  const previousEnv = _.clone(process.env);
+  const kubeApiURL = 'http://1.2.3.4:4433';
+  beforeEach(() => {
+    process.env.KUBE_API_URL = kubeApiURL;
+    sinon.stub(helpers, 'getMinikubeCredentials').returns({
+      cert: 'cert',
+      ca: 'ca',
+      key: 'key',
+    });
+  });
+  afterEach(() => {
+    process.env = previousEnv;
+    helpers.getMinikubeCredentials.restore();
+  });
+  describe('#constructor', () => {
+    const options = { test: 1 };
+    const kubelessDeploy = new KubelessDeploy(serverless, options);
+    let validateStub = null;
+    let deployStub = null;
+    const stubHooks = (kbDeploy) => {
+      validateStub = sinon.stub(kbDeploy, 'validate').returns(BbPromise.resolve());
+      deployStub = sinon.stub(kbDeploy, 'deployFunction').returns(BbPromise.resolve());
+    };
+    const restoreHooks = (kbDeploy) => {
+      kbDeploy.validate.restore();
+      kbDeploy.deployFunction.restore();
+    };
+    beforeEach(() => {
+      stubHooks(kubelessDeploy);
+    });
+    afterEach(() => {
+      restoreHooks(kubelessDeploy);
+    });
+    it('should set the serverless instance', () => {
+      expect(kubelessDeploy.serverless).to.be.eql(serverless);
+    });
+    it('should set options if provided', () => {
+      expect(kubelessDeploy.options).to.be.eql(options);
+    });
+    it('should set a provider ', () => {
+      expect(kubelessDeploy.provider).to.not.be.eql(undefined);
+    });
+    it('should have hooks', () => expect(kubelessDeploy.hooks).to.be.not.empty);
+    it(
+      'should run promise chain in order',
+      () => kubelessDeploy.hooks['deploy:deploy']().then(() => {
+        expect(validateStub.calledOnce).to.be.equal(true);
+        expect(deployStub.calledAfter(validateStub)).to.be.equal(true);
+      })
+    );
+  });
+  describe('#validate', () => {
+    it('throws an error if the variable KUBE_API_URL is not set', () => {
+      const kubelessDeploy = new KubelessDeploy(serverless);
+      delete process.env.KUBE_API_URL;
+      expect(() => kubelessDeploy.validate()).to.throw(
+        'Please specify the Kubernetes API server IP as the environment variable KUBE_API_URL'
+      );
+    });
+    it('prints a message if an unsupported option is given', () => {
+      const kubelessDeploy = new KubelessDeploy(serverless, { region: 'us-east1' });
+      sinon.stub(serverless.cli, 'log');
+      try {
+        expect(() => kubelessDeploy.validate()).to.not.throw();
+        expect(serverless.cli.log.firstCall.args).to.be.eql(
+          ['Warning: Option region is not supported for the kubeless plugin']
+        );
+      } finally {
+        serverless.cli.log.restore();
+      }
+    });
+  });
+  describe('#deploy', () => {
+    let cwd = null;
+    const serverlessWithFunction = _.defaultsDeep({}, serverless, {
+      service: {
+        functions: {
+          myFunction: {
+            handler: 'function.hello',
+          },
+        },
+      },
+    });
+    let kubelessDeploy = new KubelessDeploy(serverlessWithFunction);
+    beforeEach(() => {
+      cwd = path.join(os.tmpdir(), moment().valueOf().toString());
+      fs.mkdirSync(cwd);
+      fs.writeFileSync(path.join(cwd, 'function.py'), 'function code');
+      sinon.stub(Api.ThirdPartyResources.prototype, 'post');
+      Api.ThirdPartyResources.prototype.post.callsFake((data, ff) => {
+        ff(null, { statusCode: 200 });
+      });
+    });
+    afterEach(() => {
+      Api.ThirdPartyResources.prototype.post.restore();
+      rm(cwd);
+    });
+    it('should deploy a function', () => {
+      expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction(cwd)
+      ).to.be.fulfilled;
+      expect(Api.ThirdPartyResources.prototype.post.calledOnce).to.be.eql(true);
+      expect(Api.ThirdPartyResources.prototype.post.firstCall.args[0].body).to.be.eql(
+        { apiVersion: 'k8s.io/v1',
+          kind: 'Function',
+          metadata: { name: 'myFunction', namespace: 'default' },
+          spec:
+          { deps: '',
+            function: Buffer.from('function code', 'utf8'),
+            handler: 'function.hello',
+            runtime: 'python2.7',
+            topic: '',
+            type: 'HTTP' } }
+      );
+      expect(Api.ThirdPartyResources.prototype.post.firstCall.args[1]).to.be.a('function');
+    });
+    it('should skip a deployment if an error 409 is returned', () => {
+      Api.ThirdPartyResources.prototype.post.callsFake((data, ff) => {
+        ff({ code: 409 });
+      });
+      sinon.stub(serverlessWithFunction.cli, 'log');
+      try {
+        expect( // eslint-disable-line no-unused-expressions
+          kubelessDeploy.deployFunction(cwd)
+        ).to.be.fulfilled;
+        expect(serverlessWithFunction.cli.log.lastCall.args).to.be.eql(
+          ['The function myFunction is already deployed. Remove it if you want to deploy it again.']
+        );
+      } finally {
+        serverlessWithFunction.cli.log.restore();
+      }
+    });
+    it('should fail if a deployment returns an error code', () => {
+      Api.ThirdPartyResources.prototype.post.callsFake((data, ff) => {
+        ff({ code: 500, message: 'Internal server error' });
+      });
+      expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction(cwd)
+      ).to.be.eventually.rejectedWith(
+        'Found errors while deploying the given functions:\n' +
+        'Unable to deploy the function myFunction. Received:\n' +
+        '  Code: 500\n' +
+        '  Message: Internal server error'
+      );
+    });
+    it('should deploy the possible functions even if one of them fails', () => {
+      const serverlessWithFunctions = _.defaultsDeep({}, serverless, {
+        service: {
+          functions: {
+            myFunction1: {
+              handler: 'function.hello',
+            },
+            myFunction2: {
+              handler: 'function.hello',
+            },
+            myFunction3: {
+              handler: 'function.hello',
+            },
+          },
+        },
+      });
+      const functionsDeployed = [];
+      Api.ThirdPartyResources.prototype.post.onFirstCall().callsFake((data, ff) => {
+        functionsDeployed.push(data.body.metadata.name);
+        ff(null, { statusCode: 200 });
+      });
+      Api.ThirdPartyResources.prototype.post.onSecondCall().callsFake((data, ff) => {
+        ff({ code: 500, message: 'Internal server error' });
+      });
+      Api.ThirdPartyResources.prototype.post.onThirdCall().callsFake((data, ff) => {
+        functionsDeployed.push(data.body.metadata.name);
+        ff(null, { statusCode: 200 });
+      });
+      kubelessDeploy = new KubelessDeploy(serverlessWithFunctions);
+      expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction(cwd)
+      ).to.be.eventually.rejectedWith(
+        'Found errors while deploying the given functions:\n' +
+        'Unable to deploy the function myFunction2. Received:\n' +
+        '  Code: 500\n' +
+        '  Message: Internal server error'
+      );
+      expect(functionsDeployed).to.be.eql(['myFunction1', 'myFunction3']);
+    });
+  });
+});

--- a/test/kubelessRemove.test.js
+++ b/test/kubelessRemove.test.js
@@ -1,0 +1,211 @@
+'use strict';
+
+const _ = require('lodash');
+const Api = require('kubernetes-client');
+const BbPromise = require('bluebird');
+const chaiAsPromised = require('chai-as-promised');
+const expect = require('chai').expect;
+const helpers = require('../lib/helpers');
+const fs = require('fs');
+const moment = require('moment');
+const os = require('os');
+const path = require('path');
+const sinon = require('sinon');
+
+const KubelessRemove = require('../remove/kubelessRemove');
+const serverless = require('./lib/serverless');
+
+require('chai').use(chaiAsPromised);
+
+function rm(p) {
+  if (fs.existsSync(p)) {
+    fs.readdirSync(p).forEach((file) => {
+      const curPath = `${p}/${file}`;
+      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+        rm(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(p);
+  }
+}
+
+describe('KubelessRemove', () => {
+  const previousEnv = _.clone(process.env);
+  const kubeApiURL = 'http://1.2.3.4:4433';
+  beforeEach(() => {
+    process.env.KUBE_API_URL = kubeApiURL;
+    sinon.stub(helpers, 'getMinikubeCredentials').returns({
+      cert: 'cert',
+      ca: 'ca',
+      key: 'key',
+    });
+  });
+  afterEach(() => {
+    process.env = previousEnv;
+    helpers.getMinikubeCredentials.restore();
+  });
+  describe('#constructor', () => {
+    const options = { test: 1 };
+    const kubelessRemove = new KubelessRemove(serverless, options);
+    let validateStub = null;
+    let removeStub = null;
+    const stubHooks = (kbRemove) => {
+      validateStub = sinon.stub(kbRemove, 'validate').returns(BbPromise.resolve());
+      removeStub = sinon.stub(kbRemove, 'removeFunction').returns(BbPromise.resolve());
+    };
+    const restoreHooks = (kbRemove) => {
+      kbRemove.validate.restore();
+      kbRemove.removeFunction.restore();
+    };
+    beforeEach(() => {
+      stubHooks(kubelessRemove);
+    });
+    afterEach(() => {
+      restoreHooks(kubelessRemove);
+    });
+    it('should set the serverless instance', () => {
+      expect(kubelessRemove.serverless).to.be.eql(serverless);
+    });
+    it('should set options if provided', () => {
+      expect(kubelessRemove.options).to.be.eql(options);
+    });
+    it('should set a provider ', () => {
+      expect(kubelessRemove.provider).to.not.be.eql(undefined);
+    });
+    it('should have hooks', () => expect(kubelessRemove.hooks).to.be.not.empty);
+    it(
+      'should run promise chain in order',
+      () => kubelessRemove.hooks['remove:remove']().then(() => {
+        expect(validateStub.calledOnce).to.be.equal(true);
+        expect(removeStub.calledAfter(validateStub)).to.be.equal(true);
+      })
+    );
+  });
+  describe('#validate', () => {
+    it('throws an error if the variable KUBE_API_URL is not set', () => {
+      const kubelessRemove = new KubelessRemove(serverless);
+      delete process.env.KUBE_API_URL;
+      expect(() => kubelessRemove.validate()).to.throw(
+        'Please specify the Kubernetes API server IP as the environment variable KUBE_API_URL'
+      );
+    });
+    it('prints a message if an unsupported option is given', () => {
+      const kubelessRemove = new KubelessRemove(serverless, { region: 'us-east1' });
+      sinon.stub(serverless.cli, 'log');
+      try {
+        expect(() => kubelessRemove.validate()).to.not.throw();
+        expect(serverless.cli.log.firstCall.args).to.be.eql(
+          ['Warning: Option region is not supported for the kubeless plugin']
+        );
+      } finally {
+        serverless.cli.log.restore();
+      }
+    });
+  });
+  describe('#remove', () => {
+    let cwd = null;
+    const serverlessWithFunction = _.defaultsDeep({}, serverless, {
+      service: {
+        functions: {
+          myFunction: {
+            handler: 'function.hello',
+          },
+        },
+      },
+    });
+    let kubelessRemove = new KubelessRemove(serverlessWithFunction);
+    beforeEach(() => {
+      cwd = path.join(os.tmpdir(), moment().valueOf().toString());
+      fs.mkdirSync(cwd);
+      fs.writeFileSync(path.join(cwd, 'function.py'), 'function code');
+      sinon.stub(Api.ThirdPartyResources.prototype, 'delete');
+      Api.ThirdPartyResources.prototype.delete.callsFake((data, ff) => {
+        ff(null, { statusCode: 200 });
+      });
+    });
+    afterEach(() => {
+      Api.ThirdPartyResources.prototype.delete.restore();
+      rm(cwd);
+    });
+    it('should remove a function', () => {
+      expect( // eslint-disable-line no-unused-expressions
+        kubelessRemove.removeFunction(cwd)
+      ).to.be.fulfilled;
+      expect(Api.ThirdPartyResources.prototype.delete.calledOnce).to.be.eql(true);
+      expect(
+        Api.ThirdPartyResources.prototype.delete.firstCall.args[0].path[1]
+      ).to.be.eql('myFunction');
+      expect(Api.ThirdPartyResources.prototype.delete.firstCall.args[1]).to.be.a('function');
+    });
+    it('should skip a removal if an error 404 is returned', () => {
+      Api.ThirdPartyResources.prototype.delete.callsFake((data, ff) => {
+        ff({ code: 404 });
+      });
+      sinon.stub(serverlessWithFunction.cli, 'log');
+      try {
+        expect( // eslint-disable-line no-unused-expressions
+          kubelessRemove.removeFunction(cwd)
+        ).to.be.fulfilled;
+        expect(serverlessWithFunction.cli.log.lastCall.args).to.be.eql(
+          ['The function myFunction doesn\'t exist. Skipping removal.']
+        );
+      } finally {
+        serverlessWithFunction.cli.log.restore();
+      }
+    });
+    it('should fail if a removal returns an error code', () => {
+      Api.ThirdPartyResources.prototype.delete.callsFake((data, ff) => {
+        ff({ code: 500, message: 'Internal server error' });
+      });
+      expect( // eslint-disable-line no-unused-expressions
+        kubelessRemove.removeFunction(cwd)
+      ).to.be.eventually.rejectedWith(
+        'Found errors while removing the given functions:\n' +
+        'Unable to remove the function myFunction. Received:\n' +
+        '  Code: 500\n' +
+        '  Message: Internal server error'
+      );
+    });
+    it('should remove the possible functions even if one of them fails', () => {
+      const serverlessWithFunctions = _.defaultsDeep({}, serverless, {
+        service: {
+          functions: {
+            myFunction1: {
+              handler: 'function.hello',
+            },
+            myFunction2: {
+              handler: 'function.hello',
+            },
+            myFunction3: {
+              handler: 'function.hello',
+            },
+          },
+        },
+      });
+      const functionsRemoved = [];
+      Api.ThirdPartyResources.prototype.delete.onFirstCall().callsFake((data, ff) => {
+        functionsRemoved.push(data.path[1]);
+        ff(null, { statusCode: 200 });
+      });
+      Api.ThirdPartyResources.prototype.delete.onSecondCall().callsFake((data, ff) => {
+        ff({ code: 500, message: 'Internal server error' });
+      });
+      Api.ThirdPartyResources.prototype.delete.onThirdCall().callsFake((data, ff) => {
+        functionsRemoved.push(data.path[1]);
+        ff(null, { statusCode: 200 });
+      });
+      kubelessRemove = new KubelessRemove(serverlessWithFunctions);
+      expect( // eslint-disable-line no-unused-expressions
+        kubelessRemove.removeFunction(cwd)
+      ).to.be.eventually.rejectedWith(
+        'Found errors while removing the given functions:\n' +
+        'Unable to remove the function myFunction2. Received:\n' +
+        '  Code: 500\n' +
+        '  Message: Internal server error'
+      );
+      expect(functionsRemoved).to.be.eql(['myFunction1', 'myFunction3']);
+    });
+  });
+});

--- a/test/lib/serverless.js
+++ b/test/lib/serverless.js
@@ -13,7 +13,9 @@ const serverless = {
   classes: { Error, CLI },
   service: {
     getFunction: () => {},
-    provider: {},
+    provider: {
+      runtime: 'python2.7',
+    },
     resources: {},
     getAllFunctions: () => [],
   },


### PR DESCRIPTION
Before this PR the serverless.yaml file should contain as a service name the name of the function we want to deploy. With this change we add support for deploying and removing several functions using the same serverless definition.

We also cover the code for this two methods with unit tests.