### PR TITLE
Bump version to 0.1.0. Rename the npm name to serverless-kubeless.

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -3,14 +3,12 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "bluebird": "^3.5.0",
-    "kubernetes-client": "^3.10.1",
-    "kubeless-serverless": "^0.0.1"
+    "serverless-kubeless": "^0.1.0"
   },
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "APACHE2"
 }

--- a/examples/serverless.yml
+++ b/examples/serverless.yml
@@ -5,7 +5,7 @@ provider:
   runtime: python2.7
 
 plugins:
-  - kubeless-serverless
+  - serverless-kubeless
 
 functions:
   hello:

--- a/info/kubelessInfo.js
+++ b/info/kubelessInfo.js
@@ -1,3 +1,19 @@
+/*
+ Copyright 2017 Bitnami.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 'use strict';
 
 const _ = require('lodash');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "kubeless-serverless",
-  "version": "0.0.1",
+  "name": "serverless-kubeless",
+  "version": "0.1.0",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {
@@ -15,7 +15,7 @@
     "url": "git+https://github.com/serverless/serverless-kubeless.git"
   },
   "author": "tuna@bitnami.com",
-  "license": "ISC",
+  "license": "APACHE2",
   "bugs": {
     "url": "https://github.com/serverless/serverless-kubeless/issues"
   },

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -1,3 +1,19 @@
+/*
+ Copyright 2017 Bitnami.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 'use strict';
 
 const _ = require('lodash');

--- a/test/kubelessInfo.test.js
+++ b/test/kubelessInfo.test.js
@@ -1,3 +1,19 @@
+/*
+ Copyright 2017 Bitnami.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 'use strict';
 
 const _ = require('lodash');

--- a/test/kubelessRemove.test.js
+++ b/test/kubelessRemove.test.js
@@ -1,3 +1,19 @@
+/*
+ Copyright 2017 Bitnami.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 'use strict';
 
 const _ = require('lodash');


### PR DESCRIPTION
Prepare the code for the release of the version 0.1.0

Add the license header for the files that lacked of it.