### PR TITLE
Support for different kubernetes platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 npm-debug.log
 # ESLint cache
 .eslintcache
+coverage
+.serverless

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Kubeless is a Kubernetes-native Serverless solution.
 
 ## Pre requisites
 
-Make sure you have a kubernetes endpoint running (for the moment only minikube is supported) and kubeless installed:
+Make sure you have a kubernetes endpoint running and kubeless installed:
 
 ```
 $ minikube version
 $ kubectl version
 $ brew install kubeless/tap/kubeless
-$ kubectl create ns kubeless
-$ kubectl create -f $(curl -s https://api.github.com/repos/kubeless/kubeless/releases/latest | jq -r ".assets[] | select(.name | test(\"yaml\")) | .browser_download_url")
+$ KUBELESS_VERSION=0.0.16
+$ curl -sL https://github.com/kubeless/kubeless/releases/download/$KUBELESS_VERSION/kubeless-$KUBELESS_VERSION.yaml | kubectl create -f -
 ```
 
 Then install serverless
@@ -45,11 +45,6 @@ functions:
 Download dependencies
 ```
 $ npm install
-```
-
-Export the Kubernetes API endpoint.
-```
-$ export KUBE_API_URL=https://192.168.99.100:8443
 ```
 
 Deploy function.
@@ -105,9 +100,15 @@ Topic:
 Dependencies:
 ```
 
-Since we are using minikube to run kubernetes we can call directly the function through HTTP and the Node Port in which the function is running:
+If you are using minikube you can call directly the function through HTTP and the Node Port in which the function is running:
 ```
 $ curl  http://192.168.99.100:30018
+hello world
+```
+
+You can access the function through its HTTP interface as well using `kubectl proxy` and accessing:
+```
+$ curl http://127.0.0.1:8001/api/v1/namespaces/default/services/hello/proxy/
 hello world
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Kubeless is a Kubernetes-native Serverless solution.
 Make sure you have a kubernetes endpoint running and kubeless installed:
 
 ```
-$ minikube version
 $ kubectl version
 $ brew install kubeless/tap/kubeless
 $ KUBELESS_VERSION=0.0.16
+$ kubectl create ns kubeless
 $ curl -sL https://github.com/kubeless/kubeless/releases/download/$KUBELESS_VERSION/kubeless-$KUBELESS_VERSION.yaml | kubectl create -f -
 ```
 

--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -40,7 +40,6 @@ class KubelessDeploy {
   }
 
   validate() {
-    helpers.validateEnv();
     const unsupportedOptions = ['stage', 'region'];
     helpers.warnUnsupportedOptions(
       unsupportedOptions,
@@ -76,17 +75,13 @@ class KubelessDeploy {
 
   getThirdPartyResources() {
     return new Api.ThirdPartyResources(
-      Object.assign(helpers.getMinikubeCredentials(), {
-        url: process.env.KUBE_API_URL,
-        group: 'k8s.io',
-      })
+      helpers.getConnectionOptions(helpers.loadKubeConfig())
     );
   }
 
   deployFunction() {
     const thirdPartyResources = this.getThirdPartyResources();
     thirdPartyResources.addResource('functions');
-
     let files = {
       handler: null,
       deps: null,
@@ -118,7 +113,7 @@ class KubelessDeploy {
                   kind: 'Function',
                   metadata: {
                     name,
-                    namespace: 'default',
+                    namespace: thirdPartyResources.namespaces.namespace,
                   },
                   spec: {
                     deps: requirementsContent || '',

--- a/deployFunction/kubelessDeployFunction.js
+++ b/deployFunction/kubelessDeployFunction.js
@@ -1,0 +1,177 @@
+/*
+ Copyright 2017 Bitnami.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+const Api = require('kubernetes-client');
+const fs = require('fs');
+const helpers = require('../lib/helpers');
+const JSZip = require('jszip');
+const path = require('path');
+
+class KubelessDeploy {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options || {};
+    this.provider = this.serverless.getProvider('google');
+
+    this.hooks = {
+      'deploy:function:deploy': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.deployFunction),
+    };
+    // Store the result of loading the Zip file
+    this.loadZip = _.memoize(JSZip.loadAsync);
+  }
+
+  validate() {
+    const unsupportedOptions = ['stage', 'region'];
+    helpers.warnUnsupportedOptions(
+      unsupportedOptions,
+      this.options,
+      this.serverless.cli.log.bind(this.serverless.cli)
+    );
+    return BbPromise.resolve();
+  }
+
+  getFunctionContent(relativePath) {
+    const pkg = this.options.package ||
+      this.serverless.service.package.path;
+    let resultPromise = null;
+    if (pkg) {
+      resultPromise = this.loadZip(fs.readFileSync(pkg)).then(
+        (zip) => zip.file(relativePath).async('string')
+      );
+    } else {
+      resultPromise = new BbPromise((resolve, reject) => {
+        fs.readFile(
+          path.join(this.serverless.config.servicePath || '.', relativePath),
+          (err, d) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(d.toString());
+            }
+          });
+      });
+    }
+    return resultPromise;
+  }
+
+  getThirdPartyResources() {
+    return new Api.ThirdPartyResources(
+      helpers.getConnectionOptions(helpers.loadKubeConfig())
+    );
+  }
+
+  deployFunction() {
+    const thirdPartyResources = this.getThirdPartyResources();
+    const core = new Api.Core(helpers.getConnectionOptions(helpers.loadKubeConfig()));
+    thirdPartyResources.addResource('functions');
+    let files = {
+      handler: null,
+      deps: null,
+    };
+    const errors = [];
+    let counter = 0;
+    return new BbPromise((resolve, reject) => {
+      const func = this.serverless.service.functions[this.options.function];
+      if (this.serverless.service.provider.runtime.match(/python/)) {
+        files = {
+          handler: `${func.handler.toString().split('.')[0]}.py`,
+          deps: 'requirements.txt',
+        };
+      } else {
+        reject(
+            `The runtime ${this.serverless.service.provider.runtime} is not supported yet`
+          );
+      }
+
+      this.getFunctionContent(files.handler)
+      .then(functionContent => {
+        this.getFunctionContent(files.deps)
+        .catch(() => {
+          // No requirements found
+        })
+        .then((requirementsContent) => {
+          const funcs = {
+            apiVersion: 'k8s.io/v1',
+            kind: 'Function',
+            metadata: {
+              name: this.options.function,
+              namespace: thirdPartyResources.namespaces.namespace,
+            },
+            spec: {
+              deps: requirementsContent || '',
+              function: functionContent,
+              handler: func.handler,
+              runtime: this.serverless.service.provider.runtime,
+              topic: '',
+              type: 'HTTP',
+            },
+          };
+          console.log(functionContent);
+          // Create function
+          thirdPartyResources.ns.functions(this.options.function).put({ body: funcs }, (err) => {
+            if (err) {
+              if (err.code === 409) {
+                this.serverless.cli.log(
+                  `The function ${this.options.function} is already deployed. ` +
+                  'Remove it if you want to deploy it again.'
+                );
+              } else {
+                errors.push(
+                  `Unable to deploy the function ${this.options.function}. Received:\n` +
+                  `  Code: ${err.code}\n` +
+                  `  Message: ${err.message}`
+                );
+              }
+            } else {
+              core.pods.get((err1, podsInfo) => {
+                if (err1) reject(err1);
+                const functionPod = _.find(
+                  podsInfo.items,
+                  (pod) => pod.metadata.labels.function === this.options.function
+                );
+                console.log(functionPod.metadata.name);
+                // core.ns.pods(functionPod.metadata.name).delete((err2) => {
+                //   if (err2) throw err2;
+                this.serverless.cli.log(
+                    `Function ${this.options.function} succesfully redeployed`
+                  );
+                // });
+              });
+            }
+            counter++;
+            if (counter === _.keys(this.serverless.service.functions).length) {
+              if (_.isEmpty(errors)) {
+                resolve();
+              } else {
+                reject(
+                  `Found errors while deploying the given functions:\n${errors.join('\n')}`
+                );
+              }
+            }
+          });
+        });
+      });
+    });
+  }
+}
+
+module.exports = KubelessDeploy;

--- a/info/kubelessInfo.js
+++ b/info/kubelessInfo.js
@@ -53,7 +53,6 @@ class KubelessInfo {
   }
 
   validate() {
-    helpers.validateEnv();
     const unsupportedOptions = ['stage', 'region'];
     helpers.warnUnsupportedOptions(
       unsupportedOptions,
@@ -97,18 +96,9 @@ class KubelessInfo {
   }
 
   infoFunction(options) {
-    const core = new Api.Core(
-      Object.assign(helpers.getMinikubeCredentials(), {
-        url: process.env.KUBE_API_URL,
-        group: 'k8s.io',
-      })
-    );
-    const thirdPartyResources = new Api.ThirdPartyResources(
-      Object.assign(helpers.getMinikubeCredentials(), {
-        url: process.env.KUBE_API_URL,
-        group: 'k8s.io',
-      })
-    );
+    const connectionOptions = helpers.getConnectionOptions(helpers.loadKubeConfig());
+    const core = new Api.Core(connectionOptions);
+    const thirdPartyResources = new Api.ThirdPartyResources(connectionOptions);
     thirdPartyResources.addResource('functions');
     return new BbPromise((resolve) => {
       core.services.get((err, servicesInfo) => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -68,8 +68,8 @@ function getUserInfo(config, context) {
 }
 
 function getKubernetesAPIURL(config) {
-  const currentContex = config['current-context'];
-  const clusterInfo = getClusterInfo(config, currentContex);
+  const currentContext = config['current-context'];
+  const clusterInfo = getClusterInfo(config, currentContext);
   // Remove trailing '/' of the URL in case it exists
   return clusterInfo.cluster.server.replace(/\/$/, '');
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -18,26 +18,138 @@
 
 const _ = require('lodash');
 const fs = require('fs');
+const moment = require('moment');
 const path = require('path');
+const yaml = require('js-yaml');
 
-function print(err, result) {
-  console.log(JSON.stringify(err || result, null, 2));
-}
-
-function validateEnv() {
-  if (_.isEmpty(process.env.KUBE_API_URL)) {
+function loadKubeConfig() {
+  const kubeCfgPath = path.join(process.env.HOME, '.kube/config');
+  let config = {};
+  if (process.env.KUBECONFIG) {
+    const configFiles = process.env.KUBECONFIG.split(':');
+    _.each(configFiles, configFile => {
+      _.defaults(config, yaml.safeLoad(fs.readFileSync(configFile)));
+    });
+  } else if (!fs.existsSync(kubeCfgPath)) {
     throw new Error(
-      'Please specify the Kubernetes API server IP as the environment variable KUBE_API_URL'
+      'Unable to locate the configuration file for your cluster. ' +
+      'Make sure you have your cluster configured locally'
     );
+  } else {
+    config = yaml.safeLoad(fs.readFileSync(kubeCfgPath));
   }
+  return config;
 }
 
-function getMinikubeCredentials() {
-  return {
-    cert: fs.readFileSync(path.join(process.env.HOME, '.minikube/apiserver.crt')),
-    ca: fs.readFileSync(path.join(process.env.HOME, '.minikube/ca.crt')),
-    key: fs.readFileSync(path.join(process.env.HOME, '.minikube/apiserver.key')),
+function getContextInfo(config, context) {
+  const contextInfo = _.find(config.contexts, c => c.name === context);
+  if (!contextInfo) {
+    throw new Error(`Unable to find configuration of context ${context}`);
+  }
+  return contextInfo.context;
+}
+
+function getClusterInfo(config, context) {
+  const clusterName = getContextInfo(config, context).cluster;
+  const clusterInfo = _.find(config.clusters, c => c.name === clusterName);
+  if (!clusterInfo) {
+    throw new Error(`Unable to find cluster information for context ${context}`);
+  }
+  return clusterInfo;
+}
+
+function getUserInfo(config, context) {
+  const userName = getContextInfo(config, context).user;
+  const userInfo = _.find(config.users, u => u.name === userName);
+  if (!userInfo) {
+    throw new Error(`Unable to find user information for context ${context}`);
+  }
+  return userInfo;
+}
+
+function getKubernetesAPIURL(config) {
+  const currentContex = config['current-context'];
+  const clusterInfo = getClusterInfo(config, currentContex);
+  // Remove trailing '/' of the URL in case it exists
+  return clusterInfo.cluster.server.replace(/\/$/, '');
+}
+
+function getPropertyText(property, info) {
+  // Data could be pointing to a file or be base64 encoded
+  let result = null;
+  if (!_.isEmpty(info[property])) {
+    result = fs.readFileSync(info[property]);
+  } else if (!_.isEmpty(info[`${property}-data`])) {
+    result = Buffer.from(info[`${property}-data`], 'base64');
+  }
+  return result;
+}
+
+function getToken(userInfo) {
+  const token = _.get(userInfo, 'user.token');
+  const accessToken = _.get(userInfo, 'user.auth-provider.config.access-token');
+  if (token) {
+    return token;
+  } else if (accessToken) {
+    // Access tokens may expire so we better check the expire date
+    const expiry = moment(userInfo.user['auth-provider'].config.expiry);
+    if (expiry < moment()) {
+      throw new Error(
+        'The access token has expired. Make sure you can access your cluster and try again'
+      );
+    }
+    return accessToken;
+  }
+  return null;
+}
+
+function getConnectionOptions(config) {
+  const currentContext = config['current-context'];
+  const userInfo = getUserInfo(config, currentContext);
+  const clusterInfo = getClusterInfo(config, currentContext);
+
+  const connectionOptions = {
+    group: 'k8s.io',
+    url: getKubernetesAPIURL(config),
+    namespace: getContextInfo(config, currentContext).namespace || 'default',
   };
+  // Config certificate-authority
+  const ca = getPropertyText('certificate-authority', clusterInfo.cluster);
+  if (ca) {
+    connectionOptions.ca = ca;
+  } else {
+    // No certificate-authority found
+    connectionOptions.insecureSkipTlsVerify = true;
+  }
+  // Config authentication
+  const token = getToken(userInfo);
+  if (token) {
+    connectionOptions.auth = {
+      bearer: token,
+    };
+  } else {
+    // If there is not a valid token we can authenticate either using
+    // username and password or a certificate and a key
+    const user = _.get(userInfo, 'user.username');
+    const password = _.get(userInfo, 'user.password');
+    if (!_.isEmpty(user) && !_.isEmpty(password)) {
+      connectionOptions.auth = { user, password };
+    } else {
+      const properties = {
+        cert: 'client-certificate',
+        key: 'client-key',
+      };
+      _.each(properties, (property, key) => {
+        connectionOptions[key] = getPropertyText(property, userInfo.user);
+        if (!connectionOptions[key]) {
+          throw new Error(
+            'Unable to find required information for authenticating against the cluster'
+          );
+        }
+      });
+    }
+  }
+  return connectionOptions;
 }
 
 function warnUnsupportedOptions(unsupportedOptions, definedOptions, logFunction) {
@@ -49,8 +161,8 @@ function warnUnsupportedOptions(unsupportedOptions, definedOptions, logFunction)
 }
 
 module.exports = {
-  validateEnv,
-  getMinikubeCredentials,
-  print,
   warnUnsupportedOptions,
+  loadKubeConfig,
+  getKubernetesAPIURL,
+  getConnectionOptions,
 };

--- a/logs/kubelessLogs.js
+++ b/logs/kubelessLogs.js
@@ -68,7 +68,6 @@ class KubelessLogs {
   }
 
   validate() {
-    helpers.validateEnv();
     const unsupportedOptions = ['stage', 'region'];
     helpers.warnUnsupportedOptions(
       unsupportedOptions,
@@ -129,12 +128,7 @@ class KubelessLogs {
       filter: this.options.filter,
       silent: false,
     });
-    const core = new Api.Core(
-      Object.assign(helpers.getMinikubeCredentials(), {
-        url: process.env.KUBE_API_URL,
-        group: 'k8s.io',
-      })
-    );
+    const core = new Api.Core(helpers.getConnectionOptions(helpers.loadKubeConfig()));
     return new BbPromise((resolve, reject) => {
       core.ns.pods.get((err, podsInfo) => {
         if (err) throw new this.serverless.classes.Error(err);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/serverless/serverless-kubeless#readme",
   "dependencies": {
     "bluebird": "^3.5.0",
+    "js-yaml": "^3.9.0",
     "jszip": "^3.1.3",
     "kubernetes-client": "^3.12.0",
     "lodash": "^4.17.4",

--- a/remove/kubelessRemove.js
+++ b/remove/kubelessRemove.js
@@ -35,7 +35,6 @@ class KubelessRemove {
   }
 
   validate() {
-    helpers.validateEnv();
     const unsupportedOptions = ['stage', 'region'];
     helpers.warnUnsupportedOptions(
       unsupportedOptions,
@@ -47,10 +46,7 @@ class KubelessRemove {
 
   removeFunction() {
     const thirdPartyResources = new Api.ThirdPartyResources(
-      Object.assign(helpers.getMinikubeCredentials(), {
-        url: process.env.KUBE_API_URL,
-        group: 'k8s.io',
-      })
+      helpers.getConnectionOptions(helpers.loadKubeConfig())
     );
     thirdPartyResources.addResource('functions');
 

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,275 @@
+/*
+Copyright 2017 Bitnami.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const _ = require('lodash');
+const expect = require('chai').expect;
+const fs = require('fs');
+const helpers = require('../lib/helpers');
+const loadKubeConfig = require('./lib/load-kube-config');
+const moment = require('moment');
+const os = require('os');
+const path = require('path');
+const rm = require('./lib/rm');
+const yaml = require('js-yaml');
+
+describe('Helper functions', () => {
+  describe('#loadKubeConfig', () => {
+    const configSample = loadKubeConfig();
+    let cwd = null;
+    const previousEnv = _.cloneDeep(process.env);
+    beforeEach(() => {
+      cwd = path.join(os.tmpdir(), moment().valueOf().toString());
+      fs.mkdirSync(cwd);
+    });
+    afterEach(() => {
+      process.env = previousEnv;
+      rm(cwd);
+    });
+    it('should find kubernetes config on its default path', () => {
+      process.env.HOME = cwd;
+      fs.mkdir(path.join(cwd, '.kube'));
+      fs.writeFileSync(path.join(cwd, '.kube/config'), yaml.safeDump(configSample));
+      expect(helpers.loadKubeConfig()).to.be.eql(configSample);
+    });
+    it('should find kubernetes config specified at KUBECONFIG', () => {
+      process.env.KUBECONFIG = path.join(cwd, 'config');
+      fs.writeFileSync(path.join(cwd, 'config'), yaml.safeDump(configSample));
+      expect(helpers.loadKubeConfig()).to.be.eql(configSample);
+    });
+    it('should merge kubernetes config specified at KUBECONFIG', () => {
+      process.env.KUBECONFIG = `${path.join(cwd, 'config-1')}:${path.join(cwd, 'config-2')}`;
+      fs.writeFileSync(
+        path.join(cwd, 'config-1'),
+        yaml.safeDump(
+          _.assign({}, configSample, { 'current-context': 'cluster-id-1' })
+        )
+      );
+      fs.writeFileSync(
+        path.join(cwd, 'config-2'),
+        yaml.safeDump(
+          _.assign({}, configSample, { test: 'test-value' })
+        )
+      );
+      expect(helpers.loadKubeConfig()).to.be.eql(_.defaults(
+        { 'current-context': 'cluster-id-1' },
+        { test: 'test-value' },
+        configSample
+      ));
+    });
+  });
+  describe('#getKubernetesAPIURL', () => {
+    it('retrieves the server URL', () => {
+      const config = loadKubeConfig();
+      const expectedURL = config.clusters[0].cluster.server;
+      expect(helpers.getKubernetesAPIURL(config)).to.be.eql(expectedURL);
+    });
+    it('retrieves the server URL without the trailing /', () => {
+      const config = loadKubeConfig({
+        clusters: [
+          {
+            cluster: {
+              'certificate-authority-data': 'LS0tLS1',
+              server: 'http://1.2.3.4:4433/',
+            },
+            name: 'cluster-name',
+          },
+        ],
+      });
+      expect(helpers.getKubernetesAPIURL(config)).to.be.eql('http://1.2.3.4:4433');
+    });
+  });
+  describe('#getConnectionOptions', () => {
+    it('should return the correct options based on the current context', () => {
+      const config = {
+        'current-context': 'cluster-id-2',
+        clusters: [{
+          cluster: { 'certificate-authority-data': 'LS0tLS1', server: 'http://1.2.3.4:4433' },
+          name: 'cluster-name-1',
+        }, {
+          cluster: { 'certificate-authority-data': 'LS0tLS1', server: 'http://4.3.2.1:4433' },
+          name: 'cluster-name-2',
+        }],
+        contexts: [{
+          context: { cluster: 'cluster-name-1', user: 'cluster-user-1' },
+          name: 'cluster-id-1',
+        }, {
+          context: { cluster: 'cluster-name-2', user: 'cluster-user-2' },
+          name: 'cluster-id-2',
+        }],
+        users: [
+          { name: 'cluster-user-1', user: { username: 'admin-1', password: 'password1234' } },
+          { name: 'cluster-user-2', user: { username: 'admin-2', password: 'password4321' } },
+        ],
+      };
+      expect(helpers.getConnectionOptions(config)).to.be.eql({
+        group: 'k8s.io',
+        namespace: 'default',
+        url: 'http://4.3.2.1:4433',
+        ca: Buffer.from('LS0tLS1', 'base64'),
+        auth: {
+          user: 'admin-2',
+          password: 'password4321',
+        },
+      });
+    });
+    it('should return connection options with a certificate-authority (file)', () => {
+      const ca = path.join(os.tmpdir(), moment().valueOf().toString());
+      fs.writeFileSync(ca, 'abcdef1234');
+      const config = loadKubeConfig({
+        clusters: [
+          {
+            cluster: {
+              'certificate-authority': ca,
+              server: 'http://1.2.3.4:4433',
+            },
+            name: 'cluster-name',
+          },
+        ],
+      });
+      try {
+        expect(helpers.getConnectionOptions(config).ca.toString()).to.be.eql('abcdef1234');
+      } finally {
+        rm(ca);
+      }
+    });
+    it('should return connection options with a certificate-authority (data)', () => {
+      const config = loadKubeConfig({
+        clusters: [
+          {
+            cluster: {
+              'certificate-authority-data': 'LS0tLS1',
+              server: 'http://1.2.3.4:4433',
+            },
+            name: 'cluster-name',
+          },
+        ],
+      });
+      expect(helpers.getConnectionOptions(config).ca).to.be.eql(Buffer.from('LS0tLS1', 'base64'));
+    });
+    it('should return connection options with a token', () => {
+      const config = loadKubeConfig({
+        users: [
+          {
+            name: 'cluster-user',
+            user: {
+              token: 'token1234',
+            },
+          },
+        ],
+      });
+      expect(helpers.getConnectionOptions(config).auth).to.be.eql({
+        bearer: 'token1234',
+      });
+    });
+    it('should return connection options with an access token', () => {
+      const config = loadKubeConfig({
+        users: [
+          {
+            name: 'cluster-user',
+            user: {
+              'auth-provider': {
+                config: {
+                  'access-token': 'token1234',
+                  expiry: moment().add('1', 'm'),
+                },
+              },
+            },
+          },
+        ],
+      });
+      expect(helpers.getConnectionOptions(config).auth).to.be.eql({
+        bearer: 'token1234',
+      });
+    });
+    it('should throw an error if the access-token has expired', () => {
+      const config = loadKubeConfig({
+        users: [
+          {
+            name: 'cluster-user',
+            user: {
+              'auth-provider': {
+                config: {
+                  'access-token': 'token1234',
+                  expiry: moment().subtract('1', 'm'),
+                },
+              },
+            },
+          },
+        ],
+      });
+      expect(() => helpers.getConnectionOptions(config)).to.throw('The access token has expired');
+    });
+    it('should return connection options with user and password', () => {
+      const config = loadKubeConfig({
+        users: [
+          {
+            name: 'cluster-user',
+            user: {
+              username: 'cluster-admin',
+              password: 'admin-password',
+            },
+          },
+        ],
+      });
+      expect(helpers.getConnectionOptions(config).auth).to.be.eql({
+        user: 'cluster-admin',
+        password: 'admin-password',
+      });
+    });
+    it('should return connection options with cert and key (files)', () => {
+      const cwd = path.join(os.tmpdir(), moment().valueOf().toString());
+      fs.mkdirSync(cwd);
+      fs.writeFileSync(path.join(cwd, 'server.key'), 'abcdef1234');
+      fs.writeFileSync(path.join(cwd, 'cert.crt'), 'cert1234');
+      const config = loadKubeConfig({
+        users: [
+          {
+            name: 'cluster-user',
+            user: {
+              'client-certificate': path.join(cwd, 'cert.crt'),
+              'client-key': path.join(cwd, 'server.key'),
+            },
+          },
+        ],
+      });
+      const result = helpers.getConnectionOptions(config);
+      try {
+        expect(result.cert.toString()).to.be.eql('cert1234');
+        expect(result.key.toString()).to.be.eql('abcdef1234');
+      } finally {
+        rm(cwd);
+      }
+    });
+    it('should return connection options with cert and key (data)', () => {
+      const config = loadKubeConfig({
+        users: [
+          {
+            name: 'cluster-user',
+            user: {
+              'client-certificate-data': new Buffer('cert1234').toString('base64'),
+              'client-key-data': new Buffer('abcdef1234').toString('base64'),
+            },
+          },
+        ],
+      });
+      const result = helpers.getConnectionOptions(config);
+      expect(result.cert.toString()).to.be.eql('cert1234');
+      expect(result.key.toString()).to.be.eql('abcdef1234');
+    });
+  });
+});

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -127,6 +127,16 @@ describe('Helper functions', () => {
         },
       });
     });
+    it('should return the correct namespace based current context', () => {
+      const config = {
+        'current-context': 'cluster-id',
+        contexts: [{
+          context: { cluster: 'cluster-name', user: 'cluster-user', namespace: 'custom' },
+          name: 'cluster-id-1',
+        }],
+      };
+      expect(helpers.getConnectionOptions(config).namespace).to.be.eql('custom');
+    });
     it('should return connection options with a certificate-authority (file)', () => {
       const ca = path.join(os.tmpdir(), moment().valueOf().toString());
       fs.writeFileSync(ca, 'abcdef1234');

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -37,7 +37,7 @@ describe('Helper functions', () => {
       fs.mkdirSync(cwd);
     });
     afterEach(() => {
-      process.env = previousEnv;
+      process.env = _.cloneDeep(previousEnv);
       rm(cwd);
     });
     it('should find kubernetes config on its default path', () => {
@@ -127,14 +127,14 @@ describe('Helper functions', () => {
         },
       });
     });
-    it('should return the correct namespace based current context', () => {
-      const config = {
+    it('should return the correct namespace based on the current context', () => {
+      const config = loadKubeConfig({
         'current-context': 'cluster-id',
         contexts: [{
           context: { cluster: 'cluster-name', user: 'cluster-user', namespace: 'custom' },
-          name: 'cluster-id-1',
+          name: 'cluster-id',
         }],
-      };
+      });
       expect(helpers.getConnectionOptions(config).namespace).to.be.eql('custom');
     });
     it('should return connection options with a certificate-authority (file)', () => {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -20,7 +20,6 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 const chaiAsPromised = require('chai-as-promised');
 const expect = require('chai').expect;
-const helpers = require('../lib/helpers');
 const fs = require('fs');
 const moment = require('moment');
 const os = require('os');
@@ -61,6 +60,9 @@ function instantiateKubelessDeploy(handlerFile, depsFile, serverlessWithFunction
 
 function mockThirdPartyResources(kubelessDeploy) {
   const thirdPartyResources = {
+    namespaces: {
+      namespace: 'default',
+    },
     ns: {
       functions: {
         post: sinon.stub().callsFake((body, callback) => {
@@ -75,20 +77,6 @@ function mockThirdPartyResources(kubelessDeploy) {
 }
 
 describe('KubelessDeploy', () => {
-  const previousEnv = _.clone(process.env);
-  const kubeApiURL = 'http://1.2.3.4:4433';
-  beforeEach(() => {
-    process.env.KUBE_API_URL = kubeApiURL;
-    sinon.stub(helpers, 'getMinikubeCredentials').returns({
-      cert: 'cert',
-      ca: 'ca',
-      key: 'key',
-    });
-  });
-  afterEach(() => {
-    process.env = previousEnv;
-    helpers.getMinikubeCredentials.restore();
-  });
   describe('#constructor', () => {
     const options = { test: 1 };
     const kubelessDeploy = new KubelessDeploy(serverless, options);
@@ -127,13 +115,6 @@ describe('KubelessDeploy', () => {
     );
   });
   describe('#validate', () => {
-    it('throws an error if the variable KUBE_API_URL is not set', () => {
-      const kubelessDeploy = new KubelessDeploy(serverless);
-      delete process.env.KUBE_API_URL;
-      expect(() => kubelessDeploy.validate()).to.throw(
-        'Please specify the Kubernetes API server IP as the environment variable KUBE_API_URL'
-      );
-    });
     it('prints a message if an unsupported option is given', () => {
       const kubelessDeploy = new KubelessDeploy(serverless, { region: 'us-east1' });
       sinon.stub(serverless.cli, 'log');

--- a/test/lib/load-kube-config.js
+++ b/test/lib/load-kube-config.js
@@ -1,0 +1,53 @@
+/*
+ Copyright 2017 Bitnami.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+'use strict';
+
+const _ = require('lodash');
+
+module.exports = function (config) {
+  return _.defaults({}, config, {
+    apiVersion: 'v1',
+    'current-context': 'cluster-id',
+    clusters: [
+      {
+        cluster: {
+          'certificate-authority-data': 'LS0tLS1',
+          server: 'http://1.2.3.4:4433',
+        },
+        name: 'cluster-name',
+      },
+    ],
+    contexts: [
+      {
+        context: {
+          cluster: 'cluster-name',
+          user: 'cluster-user',
+        },
+        name: 'cluster-id',
+      },
+    ],
+    users: [
+      {
+        name: 'cluster-user',
+        user: {
+          username: 'admin',
+          password: 'password1234',
+        },
+      },
+    ],
+  });
+};

--- a/test/lib/rm.js
+++ b/test/lib/rm.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const fs = require('fs');
+
+function rm(p) {
+  if (fs.existsSync(p)) {
+    if (fs.lstatSync(p).isFile()) {
+      fs.unlinkSync(p);
+    } else {
+      fs.readdirSync(p).forEach((file) => {
+        const curPath = `${p}/${file}`;
+        if (fs.lstatSync(curPath).isDirectory()) { // recurse
+          rm(curPath);
+        } else { // delete file
+          fs.unlinkSync(curPath);
+        }
+      });
+      fs.rmdirSync(p);
+    }
+  }
+}
+
+module.exports = rm;


### PR DESCRIPTION
This PR adds support for different Kubernetes cluster providers apart from Minikube like GKE or AWS EC2.

For doing so it reads the cluster information from the Kubernetes configuration located at `$HOME/.kube/config` or any path specified in the env var `$KUBECONFIG`. From these files we need:
 - Current context.
 - Kubernetes API URL. There is no need to specify this URL with an env var anymore.
 - Authentication info. We can authenticate our request against the cluster using three different methods:
   - Using a token.
   - Using username and password.
   - Using a certificate and a key.

After gathering that information we are able to connect to the cluster independently of its provider.