### PR TITLE
Add support for NodeJS and Ruby functions

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -90,17 +90,27 @@ class KubelessDeploy {
     let counter = 0;
     return new BbPromise((resolve, reject) => {
       _.each(this.serverless.service.functions, (description, name) => {
-        if (this.serverless.service.provider.runtime.match(/python/)) {
+        const runtime = this.serverless.service.provider.runtime;
+        if (runtime.match(/python/)) {
           files = {
             handler: `${description.handler.toString().split('.')[0]}.py`,
             deps: 'requirements.txt',
           };
+        } else if (runtime.match(/node/)) {
+          files = {
+            handler: `${description.handler.toString().split('.')[0]}.js`,
+            deps: 'package.json',
+          };
+        } else if (runtime.match(/ruby/)) {
+          files = {
+            handler: `${description.handler.toString().split('.')[0]}.rb`,
+            deps: 'Gemfile',
+          };
         } else {
-          reject(
+          throw new Error(
             `The runtime ${this.serverless.service.provider.runtime} is not supported yet`
           );
         }
-
         this.getFunctionContent(files.handler)
           .then(functionContent => {
             this.getFunctionContent(files.deps)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This PR adds support for NodeJS and Ruby functions. For adding dependencies it will look for a `package.json` file in case of NodeJS and a `Gemfile` file in case of Ruby.

Note that Ruby functions won't work until https://github.com/kubeless/kubeless/issues/209 is fixed.