### PR TITLE
Add support for 'deploy function' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ $ curl http://127.0.0.1:8001/api/v1/namespaces/default/services/hello/proxy/
 hello world
 ```
 
+If you have a change in your function and you want to redeploy it you can run:
+```
+$ serverless deploy function -f hello
+Serverless: Redeploying hello...
+Serverless: Function hello succesfully deployed
+```
+
 Finally you can remove the function.
 ```
 $ serverless remove

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Kubeless is a Kubernetes-native Serverless solution.
 
 Make sure you have a kubernetes endpoint running and kubeless installed:
 
-```
+```bash
 $ kubectl version
 $ brew install kubeless/tap/kubeless
 $ KUBELESS_VERSION=0.0.16
@@ -17,14 +17,14 @@ $ curl -sL https://github.com/kubeless/kubeless/releases/download/$KUBELESS_VERS
 ```
 
 Then install serverless
-```
+```bash
 $ npm install serverless -g
 ```
 
 ## Try out the example
 
 Clone this repo and check the example function
-```
+```bash
 $ git clone https://github.com/serverless/serverless-kubeless
 $ cd examples/get-python
 $ cat serverless.yml
@@ -43,19 +43,19 @@ functions:
 ```
 
 Download dependencies
-```
+```bash
 $ npm install
 ```
 
 Deploy function.
-```
+```bash
 $ serverless deploy
 Serverless: Packaging service...
 Serverless: Function hello succesfully deployed
 ```
 
 The function will be deployed to k8s via kubeless.
-```
+```bash
 $ kubectl get function
 NAME      KIND
 hello     Function.v1.k8s.io
@@ -66,7 +66,7 @@ hello-1815473417-1ttt7   1/1       Running   0          1m
 ```
 
 Now you will be able to call the function:
-```
+```bash
 $ serverless invoke -f hello -l
 Serverless: Calling function: hello...
 --------------------------------------------------------------------
@@ -74,7 +74,7 @@ hello world
 ```
 
 You can also check the logs for the function:
-```
+```bash
 $ serverless logs -f hello
 172.17.0.1 - - [12/Jul/2017:09:47:18 +0000] "GET /healthz HTTP/1.1" 200 2 "" "Go-http-client/1.1" 0/118
 172.17.0.1 - - [12/Jul/2017:09:47:21 +0000] "GET /healthz HTTP/1.1" 200 2 "" "Go-http-client/1.1" 0/93
@@ -83,7 +83,7 @@ $ serverless logs -f hello
 ```
 
 Or you can obtain the function information:
-```
+```bash
 $ serverless info
 Service Information "hello"
 Cluster IP:  10.0.0.51
@@ -101,26 +101,26 @@ Dependencies:
 ```
 
 If you are using minikube you can call directly the function through HTTP and the Node Port in which the function is running:
-```
+```bash
 $ curl  http://192.168.99.100:30018
 hello world
 ```
 
 You can access the function through its HTTP interface as well using `kubectl proxy` and accessing:
-```
+```bash
 $ curl http://127.0.0.1:8001/api/v1/namespaces/default/services/hello/proxy/
 hello world
 ```
 
 If you have a change in your function and you want to redeploy it you can run:
-```
+```bash
 $ serverless deploy function -f hello
 Serverless: Redeploying hello...
 Serverless: Function hello succesfully deployed
 ```
 
 Finally you can remove the function.
-```
+```bash
 $ serverless remove
 Serverless: Removing function: hello...
 Serverless: Function hello succesfully deleted

--- a/deployFunction/kubelessDeployFunction.js
+++ b/deployFunction/kubelessDeployFunction.js
@@ -50,7 +50,7 @@ class KubelessDeployFunction extends KubelessDeploy {
   }
 
   deployFunction() {
-    // Pick only the funciton that we are interested in
+    // Pick only the function that we are interested in
     this.serverless.service.functions = _.pick(
       this.serverless.service.functions,
       this.options.function

--- a/deployFunction/kubelessDeployFunction.js
+++ b/deployFunction/kubelessDeployFunction.js
@@ -1,0 +1,68 @@
+/*
+Copyright 2017 Bitnami.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const _ = require('lodash');
+const BbPromise = require('bluebird');
+const KubelessDeploy = require('../deploy/kubelessDeploy');
+const moment = require('moment');
+
+class KubelessDeployFunction extends KubelessDeploy {
+  constructor(serverless, options) {
+    super(serverless, options);
+    this.hooks = {
+      'deploy:function:deploy': () => BbPromise.bind(this)
+      .then(this.validate)
+      .then(this.deployFunction),
+    };
+  }
+
+  deployFunctionAndWait(body, thirdPartyResources) {
+    const requestMoment = moment().milliseconds(0);
+    return new BbPromise((resolve, reject) => {
+      thirdPartyResources.ns.functions(body.metadata.name).put({ body }, (err) => {
+        if (err) {
+          reject(new Error(
+            `Unable to update the function ${body.metadata.name}. Received:\n` +
+            `  Code: ${err.code}\n` +
+            `  Message: ${err.message}`
+          ));
+        } else {
+          this.waitForDeployment(body.metadata.name, requestMoment);
+          resolve();
+        }
+      });
+    });
+  }
+
+  deployFunction() {
+    // Pick only the funciton that we are interested in
+    this.serverless.service.functions = _.pick(
+      this.serverless.service.functions,
+      this.options.function
+    );
+    if (_.isEmpty(this.serverless.service.functions)) {
+      throw new Error(
+        `The function ${this.options.function} is not present in the current description`
+      );
+    }
+    this.serverless.cli.log(`Redeploying ${this.options.function}...`);
+    return super.deployFunction();
+  }
+}
+
+module.exports = KubelessDeployFunction;

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ whole provider implementation.
 
 const KubelessProvider = require('./provider/kubelessProvider');
 const KubelessDeploy = require('./deploy/kubelessDeploy');
+const KubelessDeployFunction = require('./deployFunction/kubelessDeployFunction');
 const KubelessRemove = require('./remove/kubelessRemove');
 const KubelessInvoke = require('./invoke/kubelessInvoke');
 const KubelessInfo = require('./info/kubelessInfo');
@@ -36,6 +37,7 @@ class KubelessIndex {
 
     this.serverless.pluginManager.addPlugin(KubelessProvider);
     this.serverless.pluginManager.addPlugin(KubelessDeploy);
+    this.serverless.pluginManager.addPlugin(KubelessDeployFunction);
     this.serverless.pluginManager.addPlugin(KubelessRemove);
     this.serverless.pluginManager.addPlugin(KubelessInvoke);
     this.serverless.pluginManager.addPlugin(KubelessInfo);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -430,7 +430,7 @@ describe('KubelessDeploy', () => {
         kubelessDeploy.deployFunction()
       ).to.be.eventually.rejectedWith(
         'Found errors while deploying the given functions:\n' +
-        'Unable to deploy the function myFunction. Received:\n' +
+        'Error: Unable to deploy the function myFunction. Received:\n' +
         '  Code: 500\n' +
         '  Message: Internal server error'
       );
@@ -469,7 +469,7 @@ describe('KubelessDeploy', () => {
         kubelessDeploy.deployFunction()
       ).to.be.eventually.rejectedWith(
         'Found errors while deploying the given functions:\n' +
-        'Unable to deploy the function myFunction2. Received:\n' +
+        'Error: Unable to deploy the function myFunction2. Received:\n' +
         '  Code: 500\n' +
         '  Message: Internal server error'
       );

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -415,7 +415,8 @@ describe('KubelessDeploy', () => {
           kubelessDeploy.deployFunction()
         ).to.be.fulfilled;
         expect(serverlessWithFunction.cli.log.lastCall.args).to.be.eql(
-          ['The function myFunction is already deployed. Remove it if you want to deploy it again.']
+          ['The function myFunction is already deployed. ' +
+          'If you want to redeploy it execute "sls deploy function -f myFunction".']
         );
       } finally {
         serverlessWithFunction.cli.log.restore();

--- a/test/kubelessDeployFunction.test.js
+++ b/test/kubelessDeployFunction.test.js
@@ -1,0 +1,169 @@
+/*
+ Copyright 2017 Bitnami.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+'use strict';
+
+const _ = require('lodash');
+const chaiAsPromised = require('chai-as-promised');
+const expect = require('chai').expect;
+const fs = require('fs');
+const moment = require('moment');
+const os = require('os');
+const path = require('path');
+const sinon = require('sinon');
+
+const KubelessDeployFunction = require('../deployFunction/kubelessDeployFunction');
+const serverless = require('./lib/serverless');
+
+require('chai').use(chaiAsPromised);
+
+function rm(p) {
+  if (fs.existsSync(p)) {
+    fs.readdirSync(p).forEach((file) => {
+      const curPath = `${p}/${file}`;
+      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+        rm(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(p);
+  }
+}
+
+function instantiateKubelessDeploy(handlerFile, depsFile, serverlessWithFunction, options) {
+  const kubelessDeployFunction = new KubelessDeployFunction(
+    serverlessWithFunction,
+    _.defaults({ function: 'myFunction', options })
+  );
+  // Mock call to getFunctionContent when retrieving the function code
+  sinon.stub(kubelessDeployFunction, 'getFunctionContent')
+    .withArgs(path.basename(handlerFile))
+    .callsFake(() => ({ then: (f) => f(fs.readFileSync(handlerFile).toString()) }));
+  // Mock call to getFunctionContent when retrieving the requirements text
+  kubelessDeployFunction.getFunctionContent
+    .withArgs(path.basename(depsFile))
+    .callsFake(() => ({ catch: () => ({ then: (f) => {
+      if (fs.existsSync(depsFile)) {
+        return f(fs.readFileSync(depsFile).toString());
+      }
+      return f(null);
+    } }) })
+  );
+  sinon.stub(kubelessDeployFunction, 'waitForDeployment');
+  return kubelessDeployFunction;
+}
+function mockPutRequest(kubelessDeploy) {
+  const put = sinon.stub().callsFake((body, callback) => {
+    callback(null, { statusCode: 200 });
+  });
+  const thirdPartyResources = {
+    namespaces: {
+      namespace: 'default',
+    },
+    ns: {
+      functions: () => ({
+        put,
+      }),
+    },
+    addResource: sinon.stub(),
+  };
+  sinon.stub(kubelessDeploy, 'getThirdPartyResources').returns(thirdPartyResources);
+  return put;
+}
+
+describe('KubelessDeploy', () => {
+  describe('#deploy', () => {
+    const cwd = path.join(os.tmpdir(), moment().valueOf().toString());
+    let handlerFile = null;
+    let depsFile = null;
+    const serverlessWithFunction = _.defaultsDeep({}, serverless, {
+      config: {
+        servicePath: cwd,
+      },
+      service: {
+        functions: {
+          myFunction: {
+            handler: 'function.hello',
+          },
+        },
+      },
+    });
+    let kubelessDeployFunction = null;
+    let put = null;
+
+    before(() => {
+      fs.mkdirSync(cwd);
+    });
+    beforeEach(() => {
+      handlerFile = path.join(cwd, 'function.py');
+      fs.writeFileSync(handlerFile, 'function code');
+      depsFile = path.join(cwd, 'requirements.txt');
+      kubelessDeployFunction = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithFunction
+      );
+      put = mockPutRequest(kubelessDeployFunction);
+    });
+    after(() => {
+      rm(cwd);
+    });
+    it('should redeploy a function', () => {
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeployFunction.deployFunction()
+      ).to.be.fulfilled;
+
+      expect(put.calledOnce).to.be.eql(true);
+      expect(put.firstCall.args[0].body).to.be.eql(
+        { apiVersion: 'k8s.io/v1',
+          kind: 'Function',
+          metadata: { name: 'myFunction', namespace: 'default' },
+          spec:
+          { deps: '',
+            function: 'function code',
+            handler: 'function.hello',
+            runtime: 'python2.7',
+            topic: '',
+            type: 'HTTP' } }
+      );
+      expect(put.firstCall.args[1]).to.be.a('function');
+      return result;
+    });
+    it('should fail if a deployment returns an error code', () => {
+      put.callsFake((data, ff) => {
+        ff({ code: 500, message: 'Internal server error' });
+      });
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeployFunction.deployFunction()
+      ).to.be.eventually.rejectedWith(
+        'Found errors while deploying the given functions:\n' +
+        'Error: Unable to update the function myFunction. Received:\n' +
+        '  Code: 500\n' +
+        '  Message: Internal server error'
+      );
+    });
+    it('should redeploy only the chosen function', () => {
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeployFunction.deployFunction()
+      ).to.be.fulfilled;
+
+      expect(put.calledOnce).to.be.eql(true);
+      expect(put.firstCall.args[0].body.metadata.name).to.be.eql('myFunction');
+      return result;
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for the command `deploy function -f <func_name>` that allows users to update their functions easily.

The existing code of the command `deploy` has been slightly refactored so we are able to inherit from it in the new command.