### PR TITLE
Add support for custom Namespaces

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -119,7 +119,6 @@ class KubelessDeploy {
         clearInterval(loop);
         return;
       }
-      retries++;
       let runningPods = 0;
       core.pods.get((err, podsInfo) => {
         if (err) {
@@ -139,6 +138,7 @@ class KubelessDeploy {
             )
           );
           if (_.isEmpty(functionPods)) {
+            retries++;
             this.serverless.cli.log(
               `Unable to find any running pod for ${funcName}. Retrying...`
             );

--- a/info/kubelessInfo.js
+++ b/info/kubelessInfo.js
@@ -109,39 +109,38 @@ class KubelessInfo {
         core.services.get((err, servicesInfo) => {
           thirdPartyResources.ns.functions.get((ferr, functionsInfo) => {
             if (ferr) throw new this.serverless.classes.Error(ferr);
-            _.each(functionsInfo.items, fDesc => {
-              const functionService = _.find(
+            const fDesc = _.find(functionsInfo.items, item => item.metadata.name === f);
+            const functionService = _.find(
                 servicesInfo.items,
                 (service) => (
                   service.metadata.labels &&
                   service.metadata.labels.function === f
                 )
               );
-              const service = {
-                name: functionService.metadata.name,
-                ip: functionService.spec.clusterIP,
-                type: functionService.spec.type,
-                ports: functionService.spec.ports,
-                selfLink: functionService.metadata.selfLink,
-                uid: functionService.metadata.uid,
-                timestamp: functionService.metadata.creationTimestamp,
-              };
-              const func = {
-                name: f,
-                handler: fDesc.spec.handler,
-                runtime: fDesc.spec.runtime,
-                topic: fDesc.spec.topic,
-                deps: fDesc.spec.deps,
-                selfLink: fDesc.metadata.selfLink,
-                uid: fDesc.metadata.uid,
-                timestamp: fDesc.metadata.creationTimestamp,
-              };
-              message += this.formatMessage(
-                service,
-                func,
-                _.defaults({}, options, { color: true })
-              );
-            });
+            const service = {
+              name: functionService.metadata.name,
+              ip: functionService.spec.clusterIP,
+              type: functionService.spec.type,
+              ports: functionService.spec.ports,
+              selfLink: functionService.metadata.selfLink,
+              uid: functionService.metadata.uid,
+              timestamp: functionService.metadata.creationTimestamp,
+            };
+            const func = {
+              name: f,
+              handler: fDesc.spec.handler,
+              runtime: fDesc.spec.runtime,
+              topic: fDesc.spec.topic,
+              deps: fDesc.spec.deps,
+              selfLink: fDesc.metadata.selfLink,
+              uid: fDesc.metadata.uid,
+              timestamp: fDesc.metadata.creationTimestamp,
+            };
+            message += this.formatMessage(
+              service,
+              func,
+              _.defaults({}, options, { color: true })
+            );
             counter++;
             if (counter === _.keys(this.serverless.service.functions).length) {
               this.serverless.cli.consoleLog(message);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -103,7 +103,12 @@ function getToken(userInfo) {
   return null;
 }
 
-function getConnectionOptions(config) {
+function getDefaultNamespace(config) {
+  const currentContext = config['current-context'];
+  return getContextInfo(config, currentContext).namespace || 'default';
+}
+
+function getConnectionOptions(config, modif) {
   const currentContext = config['current-context'];
   const userInfo = getUserInfo(config, currentContext);
   const clusterInfo = getClusterInfo(config, currentContext);
@@ -111,7 +116,7 @@ function getConnectionOptions(config) {
   const connectionOptions = {
     group: 'k8s.io',
     url: getKubernetesAPIURL(config),
-    namespace: getContextInfo(config, currentContext).namespace || 'default',
+    namespace: getDefaultNamespace(config),
   };
   // Config certificate-authority
   const ca = getPropertyText('certificate-authority', clusterInfo.cluster);
@@ -149,7 +154,7 @@ function getConnectionOptions(config) {
       });
     }
   }
-  return connectionOptions;
+  return _.defaults({}, modif, connectionOptions);
 }
 
 function warnUnsupportedOptions(unsupportedOptions, definedOptions, logFunction) {
@@ -164,5 +169,6 @@ module.exports = {
   warnUnsupportedOptions,
   loadKubeConfig,
   getKubernetesAPIURL,
+  getDefaultNamespace,
   getConnectionOptions,
 };

--- a/remove/kubelessRemove.js
+++ b/remove/kubelessRemove.js
@@ -45,16 +45,17 @@ class KubelessRemove {
   }
 
   removeFunction() {
-    const thirdPartyResources = new Api.ThirdPartyResources(
-      helpers.getConnectionOptions(helpers.loadKubeConfig())
-    );
-    thirdPartyResources.addResource('functions');
-
     const errors = [];
     let counter = 0;
     return new BbPromise((resolve, reject) => {
-      _.each(_.keys(this.serverless.service.functions), f => {
+      _.each(this.serverless.service.functions, (desc, f) => {
         this.serverless.cli.log(`Removing function: ${f}...`);
+        const thirdPartyResources = new Api.ThirdPartyResources(
+          helpers.getConnectionOptions(helpers.loadKubeConfig(), {
+            namespace: desc.namespace || this.serverless.service.provider.namespace,
+          })
+        );
+        thirdPartyResources.addResource('functions');
         // Delete function
         thirdPartyResources.ns.functions.delete(f, (err) => {
           if (err) {

--- a/test/kubelessDeployFunction.test.js
+++ b/test/kubelessDeployFunction.test.js
@@ -26,7 +26,7 @@ const path = require('path');
 const sinon = require('sinon');
 
 const KubelessDeployFunction = require('../deployFunction/kubelessDeployFunction');
-const serverless = require('./lib/serverless');
+const serverless = require('./lib/serverless')();
 
 require('chai').use(chaiAsPromised);
 
@@ -85,7 +85,7 @@ function mockPutRequest(kubelessDeploy) {
   return put;
 }
 
-describe('KubelessDeploy', () => {
+describe('KubelessDeployFunction', () => {
   describe('#deploy', () => {
     const cwd = path.join(os.tmpdir(), moment().valueOf().toString());
     let handlerFile = null;

--- a/test/lib/serverless.js
+++ b/test/lib/serverless.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+const _ = require('lodash');
 const fs = require('fs');
 
 class CLI {
@@ -24,7 +25,8 @@ class CLI {
     this.consoleLog = function () {};
   }
 }
-const serverless = {
+
+module.exports = (modif) => _.defaultsDeep({}, modif, {
   config: () => {},
   pluginManager: { getPlugins: () => [] },
   classes: { Error, CLI },
@@ -35,6 +37,7 @@ const serverless = {
       runtime: 'python2.7',
     },
     resources: {},
+    functions: {},
     getAllFunctions: () => [],
   },
   cli: new CLI(),
@@ -49,6 +52,4 @@ const serverless = {
       return content;
     },
   },
-};
-
-module.exports = serverless;
+});


### PR DESCRIPTION
This PR enable users to specify different namespaces than the default when deploying a function. They can choose a namespace per service or per function. As an example:
```
service: hello

provider:
  name: google
  namespace: test
  runtime: python2.7

plugins:
  - serverless-kubeless

functions:
  hello:
    handler: handler.hello
  hello2:
    namespace: test2
    handler: handler.hello
```
That would deploy the function `hello` in the namespace `test` and the function `hello2` in the namespace `test2`

This completes #26 