### PR TITLE
Add event trigger support

### DIFF
--- a/examples/event-trigger-python/README.md
+++ b/examples/event-trigger-python/README.md
@@ -8,6 +8,6 @@ The topic in which the function will be listening is defined in the `events` sec
 $ npm install
 $ serverless deploy
 $ kubeless topic publish --topic hello_topic --data 'hello world!' # push a message into the queue
-$ servereless logs -f hello
+$ serverless logs -f hello
 hello world!
 ```

--- a/examples/event-trigger-python/README.md
+++ b/examples/event-trigger-python/README.md
@@ -1,0 +1,13 @@
+# Simple Event Triggered function
+
+In this example we will deploy a function that will be triggered whenever a message is published under a certain topic.
+
+The topic in which the function will be listening is defined in the `events` section of the `serverless.yml`
+
+```console
+$ npm install
+$ serverless deploy
+$ kubeless topic publish --topic hello_topic --data 'hello world!' # push a message into the queue
+$ servereless logs -f hello
+hello world!
+```

--- a/examples/event-trigger-python/handler.py
+++ b/examples/event-trigger-python/handler.py
@@ -1,0 +1,2 @@
+def hello(context):
+    return context

--- a/examples/event-trigger-python/package.json
+++ b/examples/event-trigger-python/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "hello-events",
+  "version": "1.0.0",
+  "description": "Example function for serverless kubeless",
+  "dependencies": {
+    "serverless-kubeless": "^0.1.6"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/examples/event-trigger-python/serverless.yml
+++ b/examples/event-trigger-python/serverless.yml
@@ -1,0 +1,14 @@
+service: hello
+
+provider:
+  name: google
+  runtime: python2.7
+
+plugins:
+  - serverless-kubeless
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - trigger: 'hello_topic'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -516,7 +516,7 @@ describe('KubelessDeploy', () => {
       }
       return result;
     });
-    it('should deploy a function event based', () => {
+    it('should deploy a function triggered by a topic', () => {
       const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomNamespace.service.functions[functionName].events = [{ trigger: 'topic' }];
       kubelessDeploy = instantiateKubelessDeploy(

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -343,18 +343,19 @@ describe('KubelessDeploy', () => {
     const cwd = path.join(os.tmpdir(), moment().valueOf().toString());
     let handlerFile = null;
     let depsFile = null;
+    const functionName = 'myFunction';
     const serverlessWithFunction = _.defaultsDeep({}, serverless, {
       config: {
         servicePath: cwd,
       },
       service: {
-        functions: {
-          myFunction: {
-            handler: 'function.hello',
-          },
-        },
+        functions: {},
       },
     });
+    serverlessWithFunction.service.functions[functionName] = {
+      handler: 'function.hello',
+    };
+
     let kubelessDeploy = null;
     let thirdPartyResources = null;
 
@@ -379,13 +380,12 @@ describe('KubelessDeploy', () => {
       expect(thirdPartyResources.ns.functions.post.firstCall.args[0].body).to.be.eql(
         { apiVersion: 'k8s.io/v1',
           kind: 'Function',
-          metadata: { name: 'myFunction', namespace: 'default' },
+          metadata: { name: functionName, namespace: 'default' },
           spec:
           { deps: '',
             function: 'function code',
             handler: 'function.hello',
             runtime: 'python2.7',
-            topic: '',
             type: 'HTTP' } }
       );
       expect(
@@ -410,13 +410,12 @@ describe('KubelessDeploy', () => {
       expect(thirdPartyResources.ns.functions.post.firstCall.args[0].body).to.be.eql(
         { apiVersion: 'k8s.io/v1',
           kind: 'Function',
-          metadata: { name: 'myFunction', namespace: 'default' },
+          metadata: { name: functionName, namespace: 'default' },
           spec:
           { deps: 'nodejs function deps',
             function: 'nodejs function code',
             handler: 'function.hello',
             runtime: 'nodejs6.10',
-            topic: '',
             type: 'HTTP' } }
       );
       expect(
@@ -441,13 +440,12 @@ describe('KubelessDeploy', () => {
       expect(thirdPartyResources.ns.functions.post.firstCall.args[0].body).to.be.eql(
         { apiVersion: 'k8s.io/v1',
           kind: 'Function',
-          metadata: { name: 'myFunction', namespace: 'default' },
+          metadata: { name: functionName, namespace: 'default' },
           spec:
           { deps: 'ruby function deps',
             function: 'ruby function code',
             handler: 'function.hello',
             runtime: 'ruby2.4',
-            topic: '',
             type: 'HTTP' } }
       );
       expect(
@@ -516,6 +514,30 @@ describe('KubelessDeploy', () => {
       } finally {
         serverlessWithFunction.cli.log.restore();
       }
+      return result;
+    });
+    it('should deploy a function event based', () => {
+      const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
+      serverlessWithCustomNamespace.service.functions[functionName].events = [{ trigger: 'topic' }];
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithCustomNamespace
+      );
+      thirdPartyResources = mockThirdPartyResources(kubelessDeploy);
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      expect(thirdPartyResources.ns.functions.post.calledOnce).to.be.eql(true);
+      expect(
+        thirdPartyResources.ns.functions.post.firstCall.args[0].body.spec.type
+      ).to.be.eql('PubSub');
+      expect(
+        thirdPartyResources.ns.functions.post.firstCall.args[0].body.spec.topic
+      ).to.be.eql('topic');
+      expect(
+        thirdPartyResources.ns.functions.post.firstCall.args[1]
+      ).to.be.a('function');
       return result;
     });
     it('should fail if a deployment returns an error code', () => {
@@ -594,13 +616,12 @@ describe('KubelessDeploy', () => {
       expect(thirdPartyResources.ns.functions.post.firstCall.args[0].body).to.be.eql(
         { apiVersion: 'k8s.io/v1',
           kind: 'Function',
-          metadata: { name: 'myFunction', namespace: 'default' },
+          metadata: { name: functionName, namespace: 'default' },
           spec:
           { deps: '',
             function: 'different function content',
             handler: 'function.hello',
             runtime: 'python2.7',
-            topic: '',
             type: 'HTTP' } }
               );
       expect(

--- a/test/kubelessDeployFunction.test.js
+++ b/test/kubelessDeployFunction.test.js
@@ -137,7 +137,6 @@ describe('KubelessDeployFunction', () => {
             function: 'function code',
             handler: 'function.hello',
             runtime: 'python2.7',
-            topic: '',
             type: 'HTTP' } }
       );
       expect(put.firstCall.args[1]).to.be.a('function');


### PR DESCRIPTION
This PR enable users to define a topic for triggering their functions.

Note that the `function.events` object should be an array to follow serverless conventions but it is not supported to specify more than one event source for the same function in kubeless.