### PR TITLE
Add metadata fields description and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ plugins:
 
 functions:
   hello:
+    description: 'Hello function'
     handler: handler.hello
 ```
 
@@ -94,9 +95,10 @@ Ports:
   Target Port:  8080
   Node Port:  30018
 Function Info
+Description: Hello function
 Handler:  handler.hello
 Runtime:  python2.7
-Topic:
+Trigger: HTTP
 Dependencies:
 ```
 

--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -243,6 +243,14 @@ class KubelessDeploy {
                       runtime: this.serverless.service.provider.runtime,
                     },
                   };
+                  if (description.description) {
+                    funcs.annotations = {
+                      description: description.description,
+                    };
+                  }
+                  if (description.labels) {
+                    funcs.labels = description.labels;
+                  }
                   switch (eventType) {
                     case 'http':
                       funcs.spec.type = 'HTTP';

--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -245,7 +245,7 @@ class KubelessDeploy {
                   };
                   if (description.description) {
                     funcs.annotations = {
-                      description: description.description,
+                      'kubeless.serverless.com/description': description.description,
                     };
                   }
                   if (description.labels) {

--- a/info/kubelessInfo.js
+++ b/info/kubelessInfo.js
@@ -82,8 +82,9 @@ class KubelessInfo {
       message += `  ${chalk.yellow('Timestamp: ')} ${service.timestamp}\n`;
     }
     message += `${chalk.yellow.underline('Function Info')}\n`;
-    if (f.annotations && f.annotations.description) {
-      message += `${chalk.yellow('Description:')} ${f.annotations.description}\n`;
+    if (f.annotations && f.annotations['kubeless.serverless.com/description']) {
+      message += `${chalk.yellow('Description:')} ` +
+        `${f.annotations['kubeless.serverless.com/description']}\n`;
     }
     if (f.labels) {
       message += `${chalk.yellow('Labels:\n')}`;

--- a/info/kubelessInfo.js
+++ b/info/kubelessInfo.js
@@ -82,9 +82,22 @@ class KubelessInfo {
       message += `  ${chalk.yellow('Timestamp: ')} ${service.timestamp}\n`;
     }
     message += `${chalk.yellow.underline('Function Info')}\n`;
+    if (f.annotations && f.annotations.description) {
+      message += `${chalk.yellow('Description:')} ${f.annotations.description}\n`;
+    }
+    if (f.labels) {
+      message += `${chalk.yellow('Labels:\n')}`;
+      _.each(f.labels, (v, k) => {
+        message += `${chalk.yellow(`  ${k}:`)} ${v}\n`;
+      });
+    }
     message += `${chalk.yellow('Handler: ')} ${f.handler}\n`;
     message += `${chalk.yellow('Runtime: ')} ${f.runtime}\n`;
-    message += `${chalk.yellow('Topic: ')} ${f.topic}\n`;
+    if (f.type === 'PubSub' && !_.isEmpty(f.topic)) {
+      message += `${chalk.yellow('Topic Trigger:')} ${f.topic}\n`;
+    } else {
+      message += `${chalk.yellow('Trigger: ')} ${f.type}\n`;
+    }
     message += `${chalk.yellow('Dependencies: ')} ${f.deps}`;
     if (this.options.verbose) {
       message += `\n${chalk.yellow('Metadata:')}\n`;
@@ -131,7 +144,10 @@ class KubelessInfo {
               handler: fDesc.spec.handler,
               runtime: fDesc.spec.runtime,
               topic: fDesc.spec.topic,
+              type: fDesc.spec.type,
               deps: fDesc.spec.deps,
+              annotations: fDesc.annotations,
+              labels: fDesc.labels,
               selfLink: fDesc.metadata.selfLink,
               uid: fDesc.metadata.uid,
               timestamp: fDesc.metadata.creationTimestamp,

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -540,6 +540,44 @@ describe('KubelessDeploy', () => {
       ).to.be.a('function');
       return result;
     });
+    it('should deploy a function with a description', () => {
+      const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
+      const desc = 'Test Description';
+      serverlessWithCustomNamespace.service.functions[functionName].description = desc;
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithCustomNamespace
+      );
+      thirdPartyResources = mockThirdPartyResources(kubelessDeploy);
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      expect(thirdPartyResources.ns.functions.post.calledOnce).to.be.eql(true);
+      expect(
+        thirdPartyResources.ns.functions.post.firstCall.args[0].body.annotations.description
+      ).to.be.eql(desc);
+      return result;
+    });
+    it('should deploy a function with labels', () => {
+      const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
+      const labels = { label1: 'Test Label' };
+      serverlessWithCustomNamespace.service.functions[functionName].labels = labels;
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithCustomNamespace
+      );
+      thirdPartyResources = mockThirdPartyResources(kubelessDeploy);
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      expect(thirdPartyResources.ns.functions.post.calledOnce).to.be.eql(true);
+      expect(
+        thirdPartyResources.ns.functions.post.firstCall.args[0].body.labels
+      ).to.be.eql(labels);
+      return result;
+    });
     it('should fail if a deployment returns an error code', () => {
       thirdPartyResources.ns.functions.post.callsFake((data, ff) => {
         ff({ code: 500, message: 'Internal server error' });

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -555,7 +555,8 @@ describe('KubelessDeploy', () => {
       ).to.be.fulfilled;
       expect(thirdPartyResources.ns.functions.post.calledOnce).to.be.eql(true);
       expect(
-        thirdPartyResources.ns.functions.post.firstCall.args[0].body.annotations.description
+        thirdPartyResources.ns.functions.post
+          .firstCall.args[0].body.annotations['kubeless.serverless.com/description']
       ).to.be.eql(desc);
       return result;
     });

--- a/test/kubelessInfo.test.js
+++ b/test/kubelessInfo.test.js
@@ -245,7 +245,7 @@ describe('KubelessInfo', () => {
     it('should return the description in case it exists', (done) => {
       mockGetCalls(
         [{ name: func, namespace: 'default' }],
-        { annotations: { description: 'Test Description' } }
+        { annotations: { 'kubeless.serverless.com/description': 'Test Description' } }
       );
       const kubelessInfo = new KubelessInfo(serverless, { function: func });
       kubelessInfo.infoFunction({ color: false }).then((message) => {


### PR DESCRIPTION
This PR adds the possibility of defining a `Description` and `Labels` fields in function metadata. The user could define:
serverless.yml:
```
functions:
  hello:
    handler: handler.hello
    description: 'This is a test!'
    labels:
      test: 'hello'
```
And that information would be shown with the `info` command:
```
Function Info
Description: This is a test!
Labels:
  test: hello
Handler:  handler.hello
```

It also fixes how we show the information about the function trigger source.