### PR TITLE
Add support for HTTP custom paths

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -194,6 +194,7 @@ class KubelessDeploy {
       helpers.loadKubeConfig(), { namespace })
     );
     let retries = 0;
+    let previousPodStatus = '';
     const loop = setInterval(() => {
       if (retries > 3) {
         this.serverless.cli.log(
@@ -241,10 +242,16 @@ class KubelessDeploy {
               );
               clearInterval(loop);
             } else if (this.options.verbose) {
-              this.serverless.cli.log(
-                `Waiting for function ${funcName} to be fully deployed. Pods status: ` +
-                `${_.map(functionPods, p => JSON.stringify(p.status.containerStatuses[0].state))}`
-              );
+              const currentPodStatus = _.map(functionPods, p => (
+                JSON.stringify(p.status.containerStatuses[0].state
+              )));
+              if (!_.isEqual(previousPodStatus, currentPodStatus)) {
+                this.serverless.cli.log(
+                  `Waiting for function ${funcName} to be fully deployed. Pods status: ` +
+                  `${currentPodStatus}`
+                );
+                previousPodStatus = currentPodStatus;
+              }
             }
           }
         }

--- a/deployFunction/kubelessDeployFunction.js
+++ b/deployFunction/kubelessDeployFunction.js
@@ -43,10 +43,15 @@ class KubelessDeployFunction extends KubelessDeploy {
           ));
         } else {
           this.waitForDeployment(body.metadata.name, requestMoment);
-          resolve();
+          resolve(true);
         }
       });
     });
+  }
+
+  addIngressRuleIfNecessary() {
+    // It is not necessary to add an Ingress rule again
+    return new BbPromise((r) => r());
   }
 
   deployFunction() {

--- a/deployFunction/kubelessDeployFunction.js
+++ b/deployFunction/kubelessDeployFunction.js
@@ -24,6 +24,7 @@ const moment = require('moment');
 class KubelessDeployFunction extends KubelessDeploy {
   constructor(serverless, options) {
     super(serverless, options);
+    if (this.options.v) this.options.verbose = true;
     this.hooks = {
       'deploy:function:deploy': () => BbPromise.bind(this)
       .then(this.validate)

--- a/examples/http-custom-path/README.md
+++ b/examples/http-custom-path/README.md
@@ -51,4 +51,4 @@ hello world
 
 For some providers like Google you may need to add a firewall rule for allowing the traffic for the port 80 and 443 so you can connect to the IP the ingress controller provides.
 
-Note that even though GCE has its own ingress controller available by default it is not suitable for our use since the annotation `ingress.kubernetes.io/rewrite-target` is not interpreted by that controller. You will need to deploy an Nginx controller like the one explained in the [pre requisites section](#pre-requisites).
+Note that even though GCE has its own ingress controller available by default it is not suitable for our use case since the annotation `ingress.kubernetes.io/rewrite-target` is not interpreted by that controller. You will need to deploy an Nginx controller like the one explained in the [pre requisites section](#pre-requisites).

--- a/examples/http-custom-path/README.md
+++ b/examples/http-custom-path/README.md
@@ -1,0 +1,48 @@
+# Simple Hello World function available in a certain HTTP path
+
+In this example we will deploy a function that will be available under the path `/hello`. Check the `serverless.yml` file to see the specific syntax.
+
+## Pre requisites
+
+We will need to have an Ingress controller deployed in order to be able to deploy your function in a specific path. If you don't have it yet you can deploy one executing:
+
+```
+curl -sL https://raw.githubusercontent.com/kubeless/kubeless/master/manifests/ingress/ingress-controller.yaml | kubectl create -f -  
+```
+
+## Deployment
+
+```console
+$ npm install
+$ serverless deploy -v
+Serverless: Packaging service...
+Serverless: Deploying function hello...
+Serverless: Deployed Ingress rule to map /hello
+Serverless: Waiting for function hello to be fully deployed. Pods status: {"waiting":{"reason":"PodInitializing"}}
+Serverless: Function hello succesfully deployed
+```
+
+As we can see in the logs an Ingress Rule has been deployed to run our function at `/hello`. We can know the specific URL in which the function will be listening executing `serverless info`:
+```console
+$ serverless info
+Service Information "hello"
+Cluster IP:  10.0.0.161
+Type:  NodePort
+Ports:
+  Protocol:  TCP
+  Port:  8080
+  Target Port:  8080
+  Node Port:  31444
+Function Info
+URL:  192.168.99.100/hello
+Handler:  handler.hello
+Runtime:  python2.7
+Trigger:  HTTP
+Dependencies:
+```
+
+Depending on the Ingress configuration the URL may be redirected to use the HTTPS protocol. You can call your function with a browser or executing:
+```console
+$ curl -kL 192.168.99.100/hello
+hello world
+```

--- a/examples/http-custom-path/README.md
+++ b/examples/http-custom-path/README.md
@@ -46,3 +46,9 @@ Depending on the Ingress configuration the URL may be redirected to use the HTTP
 $ curl -kL 192.168.99.100/hello
 hello world
 ```
+
+## GCE and Firewall limitation
+
+For some providers like Google you may need to add a firewall rule for allowing the traffic for the port 80 and 443 so you can connect to the IP the ingress controller provides.
+
+Note that even though GCE has its own ingress controller available by default it is not suitable for our use since the annotation `ingress.kubernetes.io/rewrite-target` is not interpreted by that controller. You will need to deploy an Nginx controller like the one explained in the [pre requisites section](#pre-requisites).

--- a/examples/http-custom-path/handler.py
+++ b/examples/http-custom-path/handler.py
@@ -1,0 +1,2 @@
+def hello():
+    return "hello world"

--- a/examples/http-custom-path/package.json
+++ b/examples/http-custom-path/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "hello",
+  "version": "1.0.0",
+  "description": "Example function for serverless kubeless",
+  "dependencies": {
+    "serverless-kubeless": "^0.1.1"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/examples/http-custom-path/serverless.yml
+++ b/examples/http-custom-path/serverless.yml
@@ -12,4 +12,4 @@ functions:
     handler: handler.hello
     events:
       - http:
-        path: /hello
+          path: /hello

--- a/examples/http-custom-path/serverless.yml
+++ b/examples/http-custom-path/serverless.yml
@@ -1,0 +1,15 @@
+service: hello
+
+provider:
+  name: google
+  runtime: python2.7
+
+plugins:
+  - serverless-kubeless
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+        path: /hello

--- a/info/kubelessInfo.js
+++ b/info/kubelessInfo.js
@@ -129,6 +129,7 @@ class KubelessInfo {
           thirdPartyResources.ns.functions.get((ferr, functionsInfo) => {
             if (ferr) throw new this.serverless.classes.Error(ferr);
             extensions.ns.ingress.get((ierr, ingressInfo) => {
+              if (ierr) throw this.serverless.classes.Error(ierr);
               const fDesc = _.find(functionsInfo.items, item => item.metadata.name === f);
               const functionService = _.find(
                 servicesInfo.items,
@@ -138,7 +139,7 @@ class KubelessInfo {
                 )
               );
               const fIngress = _.find(ingressInfo.items, item => (
-                item.metadata.labels.function === f
+                item.metadata.labels && item.metadata.labels.function === f
               ));
               let url = null;
               if (fIngress) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/kubelessDeployFunction.test.js
+++ b/test/kubelessDeployFunction.test.js
@@ -81,6 +81,10 @@ function mockPutRequest(kubelessDeploy) {
     },
     addResource: sinon.stub(),
   };
+  thirdPartyResources.ns.functions.get = () => {};
+  sinon.stub(thirdPartyResources.ns.functions, 'get').callsFake((c) => {
+    c(null, { statusCode: 200, body: { items: [] } });
+  });
   sinon.stub(kubelessDeploy, 'getThirdPartyResources').returns(thirdPartyResources);
   return put;
 }
@@ -167,8 +171,7 @@ describe('KubelessDeployFunction', () => {
     it('should not try to deploy a new ingress controller', () => {
       const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomNamespace.service.functions.myFunction.events = [{
-        http: null,
-        path: '/test',
+        http: { path: '/test' },
       }];
       kubelessDeployFunction = instantiateKubelessDeploy(
         handlerFile,

--- a/test/kubelessDeployFunction.test.js
+++ b/test/kubelessDeployFunction.test.js
@@ -164,5 +164,25 @@ describe('KubelessDeployFunction', () => {
       expect(put.firstCall.args[0].body.metadata.name).to.be.eql('myFunction');
       return result;
     });
+    it('should not try to deploy a new ingress controller', () => {
+      const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
+      serverlessWithCustomNamespace.service.functions.myFunction.events = [{
+        http: null,
+        path: '/test',
+      }];
+      kubelessDeployFunction = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithCustomNamespace
+      );
+      mockPutRequest(kubelessDeployFunction);
+      sinon.stub(kubelessDeployFunction, 'getExtensions');
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeployFunction.deployFunction().then(() => {
+          expect(kubelessDeployFunction.getExtensions.callCount).to.be.eql(0);
+        })
+      ).to.be.fulfilled;
+      return result;
+    });
   });
 });


### PR DESCRIPTION
This PR adds support for deploying functions in a specific path. This is needed to solve #33.

It does require to have an Ingress Controller running. I used the one available at https://github.com/kubeless/kubeless/blob/master/manifests/ingress/ingress-controller.yaml.

It also includes an example for deploying a function under a certain path.