### PR TITLE
Set provider to kubeless

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ cat serverless.yml
 service: hello
 
 provider:
-  name: google
+  name: kubeless
   runtime: python2.7
 
 plugins:

--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -104,7 +104,7 @@ class KubelessDeploy {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
-    this.provider = this.serverless.getProvider('google');
+    this.provider = this.serverless.getProvider('kubeless');
 
     this.hooks = {
       'deploy:deploy': () => BbPromise.bind(this)

--- a/examples/event-trigger-python/serverless.yml
+++ b/examples/event-trigger-python/serverless.yml
@@ -1,7 +1,7 @@
 service: hello
 
 provider:
-  name: google
+  name: kubeless
   runtime: python2.7
 
 plugins:

--- a/examples/get-python/serverless.yml
+++ b/examples/get-python/serverless.yml
@@ -1,7 +1,7 @@
 service: hello
 
 provider:
-  name: google
+  name: kubeless
   runtime: python2.7
 
 plugins:

--- a/examples/get-ruby/serverless.yml
+++ b/examples/get-ruby/serverless.yml
@@ -1,7 +1,7 @@
 service: version
 
 provider:
-  name: google
+  name: kubeless
   runtime: ruby2.4
 
 plugins:

--- a/examples/http-custom-path/serverless.yml
+++ b/examples/http-custom-path/serverless.yml
@@ -1,7 +1,7 @@
 service: hello
 
 provider:
-  name: google
+  name: kubeless
   runtime: python2.7
 
 plugins:

--- a/examples/multi-python/serverless.yml
+++ b/examples/multi-python/serverless.yml
@@ -1,7 +1,7 @@
 service: multi
 
 provider:
-  name: google
+  name: kubeless
   runtime: python2.7
 
 plugins:

--- a/examples/post-nodejs/serverless.yml
+++ b/examples/post-nodejs/serverless.yml
@@ -1,7 +1,7 @@
 service: capitalize
 
 provider:
-  name: google
+  name: kubeless
   runtime: nodejs6.10
 
 plugins:

--- a/examples/post-python/serverless.yml
+++ b/examples/post-python/serverless.yml
@@ -1,7 +1,7 @@
 service: echo
 
 provider:
-  name: google
+  name: kubeless
   runtime: python2.7
 
 plugins:

--- a/examples/post-ruby/serverless.yml
+++ b/examples/post-ruby/serverless.yml
@@ -1,7 +1,7 @@
 service: ping
 
 provider:
-  name: google
+  name: kubeless
   runtime: ruby2.4
 
 plugins:

--- a/info/kubelessInfo.js
+++ b/info/kubelessInfo.js
@@ -30,7 +30,7 @@ class KubelessInfo {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
-    this.provider = this.serverless.getProvider('google');
+    this.provider = this.serverless.getProvider('kubeless');
     this.commands = {
       info: {
         usage: 'Display information about the current functions',

--- a/invoke/kubelessInvoke.js
+++ b/invoke/kubelessInvoke.js
@@ -26,7 +26,7 @@ class KubelessInvoke {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
-    this.provider = this.serverless.getProvider('google');
+    this.provider = this.serverless.getProvider('kubeless');
 
     this.hooks = {
       'invoke:invoke': () => BbPromise.bind(this)

--- a/logs/kubelessLogs.js
+++ b/logs/kubelessLogs.js
@@ -27,7 +27,7 @@ class KubelessLogs {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
-    this.provider = this.serverless.getProvider('google');
+    this.provider = this.serverless.getProvider('kubeless');
     this.commands = {
       logs: {
         usage: 'Output the logs of a deployed function',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/provider/kubelessProvider.js
+++ b/provider/kubelessProvider.js
@@ -16,19 +16,17 @@
 
 'use strict';
 
-const constants = {
-  providerName: 'google',
-};
+const providerName = 'kubeless';
 
 class KubelessProvider {
   static getProviderName() {
-    return constants.providerName;
+    return providerName;
   }
 
   constructor(serverless) {
     this.serverless = serverless;
     this.provider = this;
-    this.serverless.setProvider(constants.providerName, this);
+    this.serverless.setProvider(providerName, this);
   }
 
 }

--- a/remove/kubelessRemove.js
+++ b/remove/kubelessRemove.js
@@ -25,7 +25,7 @@ class KubelessRemove {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.provider = this.serverless.getProvider('google');
+    this.provider = this.serverless.getProvider('kubeless');
 
     this.hooks = {
       'remove:remove': () => BbPromise.bind(this)


### PR DESCRIPTION
Change the `google` references with `kubeless`. This requires a serverless version `>1.19.0`.