### PR TITLE
Add support for memory limit and env vars

### DIFF
--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -696,6 +696,82 @@ describe('KubelessDeploy', () => {
       ).to.be.eql(labels);
       return result;
     });
+    it('should deploy a function with environment variables', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+      const env = { VAR: 'test', OTHER_VAR: 'test2' };
+      serverlessWithEnvVars.service.functions[functionName].environment = env;
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      thirdPartyResources = mockThirdPartyResources(kubelessDeploy);
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      expect(thirdPartyResources.ns.functions.post.calledOnce).to.be.eql(true);
+      expect(
+        thirdPartyResources.ns.functions.post.firstCall.args[0].body.spec.template.spec.containers
+      ).to.be.eql([
+        {
+          name: functionName,
+          env: [{ name: 'VAR', value: 'test' }, { name: 'OTHER_VAR', value: 'test2' }],
+        },
+      ]);
+      return result;
+    });
+    it('should deploy a function with a memory limit', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+      serverlessWithEnvVars.service.functions[functionName].memorySize = 128;
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      thirdPartyResources = mockThirdPartyResources(kubelessDeploy);
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      expect(thirdPartyResources.ns.functions.post.calledOnce).to.be.eql(true);
+      expect(
+        thirdPartyResources.ns.functions.post.firstCall.args[0].body.spec.template.spec.containers
+      ).to.be.eql([
+        {
+          name: functionName,
+          resources: {
+            limits: { memory: '128Mi' },
+            requests: { memory: '128Mi' },
+          },
+        },
+      ]);
+      return result;
+    });
+    it('should deploy a function with a memory limit (in the provider definition)', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+      serverlessWithEnvVars.service.provider.memorySize = '128Gi';
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      thirdPartyResources = mockThirdPartyResources(kubelessDeploy);
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      expect(thirdPartyResources.ns.functions.post.calledOnce).to.be.eql(true);
+      expect(
+        thirdPartyResources.ns.functions.post.firstCall.args[0].body.spec.template.spec.containers
+      ).to.be.eql([
+        {
+          name: functionName,
+          resources: {
+            limits: { memory: '128Gi' },
+            requests: { memory: '128Gi' },
+          },
+        },
+      ]);
+      return result;
+    });
     it('should deploy a function in a specific path', () => {
       const serverlessWithCustomPath = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomPath.service.functions[functionName].events = [{


### PR DESCRIPTION
This PR enable users to specify a memory limit and environment variables on its functions.

The memory limit can be set per service or per function. Environment variables are function specific.

Issue ref: #33

It depends on https://github.com/kubeless/kubeless/pull/217 so for testing this PR is necessary to build kubeless from master.

For a `serverless.yaml`:
```
service: hello

provider:
  name: google
  runtime: python2.7

plugins:
  - serverless-kubeless

functions:
  hello:
    handler: handler.hello
    environment:
      TEST: 1
    memorySize: 128Mi
```
it deploys a function:
```
spec:
  deps:
  function: |
    def hello():
        return "hello world"
  handler: handler.hello
  runtime: python2.7
  template:
    spec:
      containers:
      - env:
        - name: TEST
          value: "1"
        name: hello
        resources:
          limits:
            memory: 128Mi
          requests:
            memory: 128Mi
  type: HTTP
```