### PR TITLE
Problem: Typo in `serverless` command

### DIFF
--- a/examples/multi-python/README.md
+++ b/examples/multi-python/README.md
@@ -55,5 +55,5 @@ Hit Ctrl-C to quit.
 Finally, remove the service and associated functions
 
 ```console
-$ servereless remove
+$ serverless remove
 ```


### PR DESCRIPTION
Changed `servereless` to `serverless`