### PR TITLE
Use Custom Resources instead of Thirdparty

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -19,6 +19,7 @@
 const _ = require('lodash');
 const BbPromise = require('bluebird');
 const Api = require('kubernetes-client');
+const Functions = require('./functions');
 const helpers = require('./helpers');
 const ingressHelper = require('./ingress');
 const moment = require('moment');
@@ -182,7 +183,7 @@ function waitForDeployment(funcName, requestMoment, namespace, options) {
   });
 }
 
-function deployFunctionAndWait(body, thirdPartyResources, options) {
+function deployFunctionAndWait(body, functions, options) {
   const opts = _.defaults({}, options, {
     verbose: false,
     log: console.log,
@@ -190,27 +191,30 @@ function deployFunctionAndWait(body, thirdPartyResources, options) {
   const requestMoment = moment().milliseconds(0);
   opts.log(`Deploying function ${body.metadata.name}...`);
   return new BbPromise((resolve, reject) => {
-    thirdPartyResources.ns.functions.post({ body }, (err) => {
+    functions.post({ body }, (err, res) => {
       if (err) {
-        if (err.code === 409) {
-          opts.log(
-            `The function ${body.metadata.name} already exists. ` +
-            'Redeploy it usign --force or executing ' +
-             `"sls deploy function -f ${body.metadata.name}".`
-          );
-          resolve(false);
-        } else {
-          reject(new Error(
+        reject(new Error(
             `Unable to deploy the function ${body.metadata.name}. Received:\n` +
             `  Code: ${err.code}\n` +
             `  Message: ${err.message}`
         ));
-        }
+      } else if (res.code === 409) {
+        opts.log(
+            `The function ${body.metadata.name} already exists. ` +
+            'Redeploy it usign --force or executing ' +
+            `"sls deploy function -f ${body.metadata.name}".`
+          );
+        resolve(false);
+      } else if (res.code && res.code !== 200) {
+        reject(new Error(
+          `Unable to deploy the function ${body.metadata.name}. Received:\n` +
+          `  Code: ${res.code}\n` +
+          `  Message: ${res.message}`));
       } else {
         waitForDeployment(
             body.metadata.name,
             requestMoment,
-            thirdPartyResources.namespaces.namespace,
+            functions.namespace,
             { verbose: opts.verbose, log: opts.log }
         ).then(() => {
           resolve(true);
@@ -220,24 +224,29 @@ function deployFunctionAndWait(body, thirdPartyResources, options) {
   });
 }
 
-function redeployFunctionAndWait(body, thirdPartyResources, options) {
+function redeployFunctionAndWait(body, functions, options) {
   const opts = _.defaults({}, options, {
     verbose: false,
   });
   const requestMoment = moment().milliseconds(0);
   return new BbPromise((resolve, reject) => {
-    thirdPartyResources.ns.functions(body.metadata.name).put({ body }, (err) => {
+    functions.put(body.metadata.name, { body }, (err, res) => {
       if (err) {
         reject(new Error(
             `Unable to update the function ${body.metadata.name}. Received:\n` +
             `  Code: ${err.code}\n` +
             `  Message: ${err.message}`
         ));
+      } else if (res.code && res.code !== 200) {
+        reject(new Error(
+          `Unable to update the function ${body.metadata.name}. Received:\n` +
+          `  Code: ${res.code}\n` +
+          `  Message: ${res.message}`));
       } else {
         waitForDeployment(
           body.metadata.name,
           requestMoment,
-          thirdPartyResources.namespaces.namespace,
+          functions.namespace,
           { verbose: opts.verbose, log: opts.log }
         ).then(() => {
           resolve(true);
@@ -250,7 +259,7 @@ function redeployFunctionAndWait(body, thirdPartyResources, options) {
 function deploy(functions, runtime, options) {
   const opts = _.defaults({}, options, {
     hostname: null,
-    namespace: null,
+    namespace: 'default',
     memorySize: null,
     force: false,
     verbose: false,
@@ -261,20 +270,16 @@ function deploy(functions, runtime, options) {
   return new BbPromise((resolve, reject) => {
     _.each(functions, (description) => {
       if (description.handler) {
-        const connectionOptions = helpers.getConnectionOptions(
-              helpers.loadKubeConfig(), {
-                namespace: description.namespace || opts.namespace,
-              }
-          );
-        const thirdPartyResources = new Api.ThirdPartyResources(connectionOptions);
-        thirdPartyResources.addResource('functions');
+        const functionsApi = new Functions({
+          namespace: description.namespace || opts.namespace,
+        });
         const events = !_.isEmpty(description.events) ?
           description.events :
           [{ type: 'http', path: '/' }];
         _.each(events, event => {
           const funcs = getFunctionDescription(
               description.id,
-              thirdPartyResources.namespaces.namespace,
+              functionsApi.namespace,
               runtime,
               description.deps,
               description.text,
@@ -288,7 +293,7 @@ function deploy(functions, runtime, options) {
           );
           let deploymentPromise = null;
           let redeployed = false;
-          thirdPartyResources.ns.functions.get((err, functionsInfo) => {
+          functionsApi.get((err, functionsInfo) => {
             if (err) throw err;
             // Check if the function has been already deployed
             let existingFunction = false;
@@ -309,14 +314,14 @@ function deploy(functions, runtime, options) {
               // The function already exits but with a different content
               deploymentPromise = redeployFunctionAndWait(
                 funcs,
-                thirdPartyResources,
+                functionsApi,
                 { verbose: opts.verbose, log: opts.log }
               );
               redeployed = true;
             } else {
               deploymentPromise = deployFunctionAndWait(
                 funcs,
-                thirdPartyResources,
+                functionsApi,
                 { verbose: opts.verbose, log: opts.log }
               );
             }
@@ -338,7 +343,7 @@ function deploy(functions, runtime, options) {
                       verbose: opts.verbose,
                       log: opts.log,
                       hostname: opts.hostname,
-                      namespace: connectionOptions.namespace,
+                      namespace: functionsApi.namespace,
                     });
                     p.catch(ingressErr => {
                       errors.push(ingressErr);

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,0 +1,102 @@
+/*
+ Copyright 2017 Bitnami.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+'use strict';
+
+const _ = require('lodash');
+const helpers = require('./helpers');
+const request = require('request');
+
+class Functions {
+  constructor(options) {
+    const opts = _.defaults({}, options, {
+      namespace: 'default',
+    });
+    this.namespace = opts.namespace;
+    const APIRootUrl = helpers.getKubernetesAPIURL(helpers.loadKubeConfig());
+    const url = `${APIRootUrl}/apis/k8s.io/v1/namespaces/${opts.namespace}/functions/`;
+    this.connectionOptions = Object.assign(
+        helpers.getConnectionOptions(helpers.loadKubeConfig()),
+        { url, json: true }
+    );
+  }
+  get(callback) {
+    const data = [];
+    request.get(this.connectionOptions)
+    .on('error', err => {
+      callback(err);
+    })
+    .on('data', (d) => {
+      data.push(d);
+    })
+    .on('end', () => {
+      const res = Buffer.concat(data).toString();
+      callback(null, JSON.parse(res));
+    });
+  }
+  post(body, callback) {
+    const data = [];
+    request.post(_.assign(body, this.connectionOptions))
+    .on('error', err => {
+      callback(err);
+    })
+      .on('data', (d) => {
+        data.push(d);
+      })
+      .on('end', () => {
+        const res = Buffer.concat(data).toString();
+        callback(null, JSON.parse(res));
+      });
+  }
+  put(resourceID, body, callback) {
+    const data = [];
+    request.patch(_.assign({}, body, this.connectionOptions, {
+      url: `${this.connectionOptions.url}${resourceID}`,
+      headers: {
+        'Content-Type': 'application/merge-patch+json',
+      },
+      json: true,
+    }))
+    .on('error', err => {
+      callback(err);
+    })
+    .on('data', (d) => {
+      data.push(d);
+    })
+    .on('end', () => {
+      const res = Buffer.concat(data).toString();
+      callback(null, JSON.parse(res));
+    });
+  }
+  delete(resourceID, callback) {
+    const data = [];
+    request.delete(_.assign({}, this.connectionOptions, {
+      url: `${this.connectionOptions.url}${resourceID}`,
+    }))
+      .on('error', err => {
+        callback(err);
+      })
+      .on('data', (d) => {
+        data.push(d);
+      })
+      .on('end', () => {
+        const res = Buffer.concat(data).toString();
+        callback(null, JSON.parse(res));
+      });
+  }
+}
+
+module.exports = Functions;

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -68,7 +68,6 @@ class Functions {
       headers: {
         'Content-Type': 'application/merge-patch+json',
       },
-      json: true,
     }))
     .on('error', err => {
       callback(err);

--- a/lib/get-info.js
+++ b/lib/get-info.js
@@ -19,6 +19,7 @@
 const _ = require('lodash');
 const Api = require('kubernetes-client');
 const BbPromise = require('bluebird');
+const Functions = require('./functions');
 const chalk = require('chalk');
 const helpers = require('./helpers');
 const ingressHelper = require('./ingress');
@@ -83,24 +84,25 @@ function formatMessage(service, f, options) {
 
 function info(functions, options) {
   const opts = _.defaults({}, options, {
-    namespace: null,
+    namespace: 'default',
     verbose: false,
     log: console.log,
+    color: true,
   });
   let counter = 0;
   let message = '';
   return new BbPromise((resolve, reject) => {
     _.each(functions, (desc, f) => {
+      const namespace = desc.namespace || opts.namespace;
       const connectionOptions = helpers.getConnectionOptions(helpers.loadKubeConfig(), {
-        namespace: desc.namespace || opts.namespace,
+        namespace,
       });
       const core = new Api.Core(connectionOptions);
-      const thirdPartyResources = new Api.ThirdPartyResources(connectionOptions);
+      const functionsAPI = new Functions({ namespace });
       const extensions = new Api.Extensions(connectionOptions);
-      thirdPartyResources.addResource('functions');
       core.services.get((err, servicesInfo) => {
         if (err) reject(new Error(err));
-        thirdPartyResources.ns.functions.get((ferr, functionsInfo) => {
+        functionsAPI.get((ferr, functionsInfo) => {
           if (ferr) reject(new Error(ferr));
           if (_.isEmpty(functionsInfo)) {
             reject(new Error('Unable to find any function'));
@@ -156,7 +158,7 @@ function info(functions, options) {
                 message += formatMessage(
                   service,
                   func,
-                  _.defaults({}, opts, { color: true }),
+                  _.defaults({}, opts, { color: opts.color }),
                   { verbose: opts.verbose }
                 );
               }

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -17,14 +17,13 @@
 'use strict';
 
 const _ = require('lodash');
-const Api = require('kubernetes-client');
 const BbPromise = require('bluebird');
-const helpers = require('../lib/helpers');
+const Functions = require('./functions');
 const ingressHelper = require('./ingress');
 
 function removeFunction(functions, options) {
   const opts = _.defaults({}, options, {
-    namespace: null,
+    namespace: 'default',
     verbose: false,
     log: console.log,
   });
@@ -33,49 +32,48 @@ function removeFunction(functions, options) {
   return new BbPromise((resolve, reject) => {
     _.each(functions, (desc) => {
       opts.log(`Removing function: ${desc.id}...`);
-      const connectionOptions = helpers.getConnectionOptions(helpers.loadKubeConfig(), {
+      const functionsApi = new Functions({
         namespace: desc.namespace || opts.namespace,
       });
-      const thirdPartyResources = new Api.ThirdPartyResources(connectionOptions);
-      thirdPartyResources.addResource('functions');
       // Delete function
-      thirdPartyResources.ns.functions.delete(desc.id, (err) => {
+      functionsApi.delete(desc.id, (err, res) => {
         if (err) {
-          if (err.code === 404) {
-            opts.log(
-              `The function ${desc.id} doesn't exist. ` +
-              'Skipping removal.'
-            );
+          errors.push(
+            `Unable to remove the function ${desc.id}. Received:\n` +
+            `  Code: ${err.code}\n` +
+            `  Message: ${err.message}`
+          );
+        } else if (res.code && res.code !== 200) {
+          if (res.code === 404) {
+            opts.log('The function myFunction doesn\'t exist. Skipping removal.');
           } else {
             errors.push(
               `Unable to remove the function ${desc.id}. Received:\n` +
-              `  Code: ${err.code}\n` +
-              `  Message: ${err.message}`
-            );
+              `  Code: ${res.code}\n` +
+              `  Message: ${res.message}`);
           }
-        } else {
-          counter++;
-          if (counter === _.keys(functions).length) {
-            ingressHelper.removeIngressRuleIfNecessary(
-              functions,
-              connectionOptions.namespace,
-              { verbose: opts.verbose, log: opts.log }
-            )
-            .catch((ingErr) => {
-              errors.push(ingErr);
-            })
-            .then(() => {
-              if (_.isEmpty(errors)) {
-                opts.log('Functions successfully deleted');
-                resolve();
-              } else {
-                reject(
-                  'Found errors while removing the given functions:\n' +
-                  `${errors.join('\n')}`
-                );
-              }
-            });
-          }
+        }
+        counter++;
+        if (counter === _.keys(functions).length) {
+          ingressHelper.removeIngressRuleIfNecessary(
+            functions,
+            functionsApi.namespace,
+            { verbose: opts.verbose, log: opts.log }
+          )
+          .catch((ingErr) => {
+            errors.push(ingErr);
+          })
+          .then(() => {
+            if (_.isEmpty(errors)) {
+              opts.log('Functions successfully deleted');
+              resolve();
+            } else {
+              reject(
+                'Found errors while removing the given functions:\n' +
+                `${errors.join('\n')}`
+              );
+            }
+          });
         }
       });
     });

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-react": "^6.1.1",
     "fs-extra": "^4.0.1",
     "mocha": "^3.4.2",
-    "nock": "^9.0.14",
+    "nock": "9.0.14",
     "request": "^2.81.0",
     "sinon": "^2.3.6"
   }

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -438,6 +438,7 @@ describe('KubelessDeploy', () => {
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'PubSub',
+        topic: 'topic',
       });
       const result = expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()

--- a/test/kubelessDeployFunction.test.js
+++ b/test/kubelessDeployFunction.test.js
@@ -119,7 +119,7 @@ describe('KubelessDeployFunction', () => {
         }],
       });
       nock(config.clusters[0].cluster.server)
-        .put(`/apis/k8s.io/v1/namespaces/default/functions/${functionName}`, {
+        .patch(`/apis/k8s.io/v1/namespaces/default/functions/${functionName}`, {
           apiVersion: 'k8s.io/v1',
           kind: 'Function',
           metadata: { name: 'myFunction', namespace: 'default' },
@@ -131,7 +131,7 @@ describe('KubelessDeployFunction', () => {
             type: 'HTTP',
           },
         })
-        .reply(200, 'OK');
+        .reply(200, '{"message": "OK"}');
     });
     afterEach(() => {
       mocks.restoreKubeConfig(cwd);

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -115,15 +115,15 @@ function createDeploymentNocks(endpoint, func, funcSpec, options) {
   }
   nock(endpoint)
     .persist()
-    .get(`/apis/k8s.io/v1/namespaces/${opts.namespace}/functions`)
-    .reply(200, { items: opts.existingFunctions });
+    .get(`/apis/k8s.io/v1/namespaces/${opts.namespace}/functions/`)
+    .reply(200, JSON.stringify({ items: opts.existingFunctions }));
   nock(endpoint)
-    .post(`/apis/k8s.io/v1/namespaces/${opts.namespace}/functions`, postBody)
-    .reply(200, opts.postReply);
+    .post(`/apis/k8s.io/v1/namespaces/${opts.namespace}/functions/`, postBody)
+    .reply(200, JSON.stringify(opts.postReply));
   nock(endpoint)
     .persist()
     .get('/api/v1/pods')
-    .reply(200, {
+    .reply(200, JSON.stringify({
       items: [{
         metadata: {
           name: func,
@@ -135,7 +135,7 @@ function createDeploymentNocks(endpoint, func, funcSpec, options) {
           containerStatuses: [{ ready: true, restartCount: 0 }],
         },
       }],
-    });
+    }));
 }
 
 function createIngressNocks(endpoint, func, hostname, p, options) {


### PR DESCRIPTION
ThirdpartyResources are deprecated. In this PR, following Kubeless, we have migrated the API requests to create CustomResources.

This requires Kubernetes >= 1.7