### PR TITLE
Check 'pod.metadata.labels' exists before using it

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -142,6 +142,7 @@ function waitForDeployment(funcName, requestMoment, namespace, options) {
           const functionPods = _.filter(
             podsInfo.items,
             (pod) => (
+              !_.isEmpty(pod.metadata.labels) &&
               pod.metadata.labels.function === funcName &&
               // Ignore pods that may still exist from a previous deployment
               moment(pod.metadata.creationTimestamp) >= requestMoment


### PR DESCRIPTION
In my cluster `serverless deploy` throws a exception when detecting the pods after deployment is finished.
Here is the screenshot.

![image](https://user-images.githubusercontent.com/5366582/32545286-289ebc72-c4b6-11e7-9033-068c23a7c202.png)

After some checking I found out there are some pods in my cluster do not have the property 'metadata.labels', so I added some checking before it is being referenced.

I don't have much experience in Javascript, please feel free to tell me if the fix is not appropriate.