### PR TITLE
Make 'environment' schema compatible with k8s

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -67,9 +67,17 @@ function getFunctionDescription(
     };
     if (env) {
       container.env = [];
-      _.each(env, (v, k) => {
-        container.env.push({ name: k, value: v.toString() });
-      });
+      if (_.isPlainObject(env)) {
+        _.each(env, (v, k) => {
+          container.env.push({ name: k, value: v.toString() });
+        });
+      } else if (_.isArray(env)) {
+        container.env = _.cloneDeep(env);
+      } else {
+        throw new Error(
+          "Format of 'environment' is unknown: neither dictionary(object) nor array."
+        );
+      }
     }
     if (memory) {
       // If no suffix is given we assume the unit will be `Mi`

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -510,7 +510,7 @@ describe('KubelessDeploy', () => {
       ).to.be.fulfilled;
       return result;
     });
-    it('should deploy a function with environment variables', () => {
+    it('should deploy a function with environment variables defined as a dictionary', () => {
       const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
       const env = { VAR: 'test', OTHER_VAR: 'test2' };
       serverlessWithEnvVars.service.functions[functionName].environment = env;
@@ -530,6 +530,44 @@ describe('KubelessDeploy', () => {
             containers: [{
               name: functionName,
               env: [{ name: 'VAR', value: 'test' }, { name: 'OTHER_VAR', value: 'test2' }],
+            }],
+          },
+        },
+      });
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      return result;
+    });
+    it('should deploy a function with environment variables defined as an array)', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+      const env = [
+        { name: 'VAR', value: 'test' },
+        { name: 'OTHER_VAR', valueFrom: { someRef: { name: 'REF_OBJECT', key: 'REF_KEY' } } },
+      ];
+      serverlessWithEnvVars.service.functions[functionName].environment = env;
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
+        deps: '',
+        function: functionText,
+        handler: serverlessWithFunction.service.functions[functionName].handler,
+        runtime: serverlessWithFunction.service.provider.runtime,
+        type: 'HTTP',
+        template: {
+          spec: {
+            containers: [{
+              name: functionName,
+              env: [
+                { name: 'VAR', value: 'test' },
+                {
+                  name: 'OTHER_VAR',
+                  valueFrom: { someRef: { name: 'REF_OBJECT', key: 'REF_KEY' } },
+                },
+              ],
             }],
           },
         },


### PR DESCRIPTION
This fix allows the user to mount secrets/configmaps as env var.
Before the fix one specifies key/value pairs as a dictionary:
```
  environment:
    FOO: BAR
    PASSWORD: xxxxx
```
After the fix the value of 'environment' key is directly passed to k8s,
which allows for:

```
  environment:
    - name: FOO
      value: BAR
    - name: PASSWORD
      valueFrom:
        secretKeyRef:
          name: my-secret
          value: my-password
```