### PR TITLE
Add support for custom runtime image

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -99,6 +99,7 @@ class KubelessDeploy {
                       id: name,
                       text: functionContent,
                       deps: requirementsContent,
+                      image: description.image || this.serverless.service.provider.image,
                       events: _.map(description.events, (event) => {
                         const type = _.keys(event)[0];
                         if (type === 'trigger') {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -28,6 +28,7 @@ function getFunctionDescription(
     funcName,
     namespace,
     runtime,
+    image,
     deps,
     funcContent,
     handler,
@@ -61,10 +62,13 @@ function getFunctionDescription(
   if (labels) {
     funcs.metadata.labels = labels;
   }
-  if (env || memory) {
+  if (image || env || memory) {
     const container = {
       name: funcName,
     };
+    if (image) {
+      container.image = image;
+    }
     if (env) {
       container.env = [];
       if (_.isPlainObject(env)) {
@@ -298,6 +302,7 @@ function deploy(functions, runtime, options) {
               description.id,
               functionsApi.namespace,
               runtime,
+              description.image,
               description.deps,
               description.text,
               description.handler,

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -194,6 +194,88 @@ describe('KubelessDeploy', () => {
         kubelessDeploy.deployFunction()
       ).to.be.fulfilled;
     });
+    it('should deploy a function with custom runtime image (in the provider section)', () => {
+      const serverlessWithImage = _.cloneDeep(serverlessWithFunction);
+      serverlessWithImage.service.provider.image = 'some-custom-image';
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithImage
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
+        deps: '',
+        function: functionText,
+        handler: serverlessWithFunction.service.functions[functionName].handler,
+        runtime: serverlessWithFunction.service.provider.runtime,
+        type: 'HTTP',
+        template: {
+          spec: {
+            containers: [{
+              name: functionName,
+              image: 'some-custom-image',
+            }],
+          },
+        },
+      });
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
+    it('should deploy a function with custom runtime image (in the function section)', () => {
+      const serverlessWithImage = _.cloneDeep(serverlessWithFunction);
+      serverlessWithImage.service.functions[functionName].image = 'some-custom-image';
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithImage
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
+        deps: '',
+        function: functionText,
+        handler: serverlessWithFunction.service.functions[functionName].handler,
+        runtime: serverlessWithFunction.service.provider.runtime,
+        type: 'HTTP',
+        template: {
+          spec: {
+            containers: [{
+              name: functionName,
+              image: 'some-custom-image',
+            }],
+          },
+        },
+      });
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
+    it('should deploy a function with overriding runtime image', () => {
+      const serverlessWithImage = _.cloneDeep(serverlessWithFunction);
+      serverlessWithImage.service.provider.image = 'global-custom-image';
+      serverlessWithImage.service.functions[functionName].image = 'local-custom-image';
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithImage
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
+        deps: '',
+        function: functionText,
+        handler: serverlessWithFunction.service.functions[functionName].handler,
+        runtime: serverlessWithFunction.service.provider.runtime,
+        type: 'HTTP',
+        template: {
+          spec: {
+            containers: [{
+              name: functionName,
+              image: 'local-custom-image',
+            }],
+          },
+        },
+      });
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
     it('should deploy a function in a custom namespace (in the provider section)', () => {
       const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomNamespace.service.provider.namespace = 'custom';


### PR DESCRIPTION
Allow the user optionally specify custom runtime image with:
1. `service.provider.image`
2. `service.provider.functions.<function_id>.image`
The second one overrides the first one.

closes #81