### PR TITLE
Fixing functions deployment issue from Windows

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -26,7 +26,15 @@ function loadKubeConfig() {
   const kubeCfgPath = path.join(process.env.HOME, '.kube/config');
   let config = {};
   if (process.env.KUBECONFIG) {
-    const configFiles = process.env.KUBECONFIG.split(':');
+    // KUBECONFIG paths list is semicolon delimited for Windows
+    // and colon delimited for Mac and Linux
+    let kubeConfigDelimiter;
+    if (process.platform === 'win32') {
+      kubeConfigDelimiter = ';';
+    } else {
+      kubeConfigDelimiter = ':';
+    }
+    const configFiles = process.env.KUBECONFIG.split(kubeConfigDelimiter);
     _.each(configFiles, configFile => {
       _.defaults(config, yaml.safeLoad(fs.readFileSync(configFile)));
     });


### PR DESCRIPTION
This change fixes #93 

Added a conditional check for KUBECONFIG paths list delimiter based on OS to fix deployment issue from Windows. Tested locally.