### PR TITLE
Add support for specifying port and timeout of functions

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -136,6 +136,7 @@ class KubelessDeploy {
         force: this.options.force,
         verbose: this.options.verbose,
         log: this.serverless.cli.log.bind(this.serverless.cli),
+        timeout: this.serverless.service.provider.timeout,
       }
     ));
   }

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -55,12 +55,18 @@ function getFunctionDescription(
       handler,
       runtime,
       timeout: String(timeout || '180'),
-      service: [{
-        name: 'function-port',
-        port: Number(port || 8080),
-        protocol: 'TCP',
-        targetPort: Number(port || 8080),
-      }],
+      service: {
+        ports: [{
+          name: 'function-port',
+          port: Number(port || 8080),
+          protocol: 'TCP',
+          targetPort: Number(port || 8080),
+        }],
+        selector: _.assign({}, labels, {
+          function: funcName,
+        }),
+        type: 'ClusterIP',
+      },
     },
   };
   if (desc) {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -38,7 +38,9 @@ function getFunctionDescription(
     memory,
     eventType,
     eventTrigger,
-    eventSchedule
+    eventSchedule,
+    timeout,
+    port
 ) {
   const funcs = {
     apiVersion: 'k8s.io/v1',
@@ -52,6 +54,13 @@ function getFunctionDescription(
       function: funcContent,
       handler,
       runtime,
+      timeout: String(timeout || '180'),
+      service: [{
+        name: 'function-port',
+        port: Number(port || 8080),
+        protocol: 'TCP',
+        targetPort: Number(port || 8080),
+      }],
     },
   };
   if (desc) {
@@ -312,7 +321,9 @@ function deploy(functions, runtime, options) {
               description.memorySize || opts.memorySize,
               event.type,
               event.trigger,
-              event.schedule
+              event.schedule,
+              description.timeout || opts.timeout,
+              description.port
           );
           let deploymentPromise = null;
           let redeployed = false;

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -459,12 +459,18 @@ describe('KubelessDeploy', () => {
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
         timeout: '180',
-        service: [{
-          name: 'function-port',
-          port: 8080,
-          protocol: 'TCP',
-          targetPort: 8080,
-        }],
+        service: {
+          ports: [{
+            name: 'function-port',
+            port: 8080,
+            protocol: 'TCP',
+            targetPort: 8080,
+          }],
+          selector: {
+            function: functionName,
+          },
+          type: 'ClusterIP',
+        },
       };
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, funcSpec, {
         existingFunctions: [{
@@ -1192,12 +1198,18 @@ describe('KubelessDeploy', () => {
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
-        service: [{
-          name: 'function-port',
-          port: 1234,
-          protocol: 'TCP',
-          targetPort: 1234,
-        }],
+        service: {
+          ports: [{
+            name: 'function-port',
+            port: 1234,
+            protocol: 'TCP',
+            targetPort: 1234,
+          }],
+          selector: {
+            function: functionName,
+          },
+          type: 'ClusterIP',
+        },
       });
       const result = expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -458,6 +458,13 @@ describe('KubelessDeploy', () => {
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
+        timeout: '180',
+        service: [{
+          name: 'function-port',
+          port: 8080,
+          protocol: 'TCP',
+          targetPort: 8080,
+        }],
       };
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, funcSpec, {
         existingFunctions: [{
@@ -1128,6 +1135,74 @@ describe('KubelessDeploy', () => {
         '  Code: 500\n' +
         '  Message: Internal server error'
         );
+    });
+    it('should deploy a function with a timeout (in the function)', () => {
+      const serverlessWithCustomProperties = _.cloneDeep(serverlessWithFunction);
+      serverlessWithCustomProperties.service.functions[functionName].timeout = 10;
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithCustomProperties
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
+        deps: '',
+        function: functionText,
+        handler: serverlessWithFunction.service.functions[functionName].handler,
+        runtime: serverlessWithFunction.service.provider.runtime,
+        type: 'HTTP',
+        timeout: '10',
+      });
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      return result;
+    });
+    it('should deploy a function with a timeout (in the provider)', () => {
+      const serverlessWithCustomProperties = _.cloneDeep(serverlessWithFunction);
+      serverlessWithCustomProperties.service.provider.timeout = 10;
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithCustomProperties
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
+        deps: '',
+        function: functionText,
+        handler: serverlessWithFunction.service.functions[functionName].handler,
+        runtime: serverlessWithFunction.service.provider.runtime,
+        type: 'HTTP',
+        timeout: '10',
+      });
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      return result;
+    });
+    it('should deploy a function with a custom port', () => {
+      const serverlessWithCustomProperties = _.cloneDeep(serverlessWithFunction);
+      serverlessWithCustomProperties.service.functions[functionName].port = 1234;
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithCustomProperties
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
+        deps: '',
+        function: functionText,
+        handler: serverlessWithFunction.service.functions[functionName].handler,
+        runtime: serverlessWithFunction.service.provider.runtime,
+        type: 'HTTP',
+        service: [{
+          name: 'function-port',
+          port: 1234,
+          protocol: 'TCP',
+          targetPort: 1234,
+        }],
+      });
+      const result = expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+      return result;
     });
   });
 });


### PR DESCRIPTION
Kubeless now support to specify the function port and the maximum timeout for the function execution. This PR adapt the serverless.yaml syntax to accept those parameters.