### PR TITLE
Use serverless packaged zip. Skip node_modules

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -22,7 +22,6 @@ const deploy = require('../lib/deploy');
 const fs = require('fs');
 const helpers = require('../lib/helpers');
 const JSZip = require('jszip');
-const path = require('path');
 
 class KubelessDeploy {
   constructor(serverless, options) {
@@ -31,12 +30,20 @@ class KubelessDeploy {
     this.provider = this.serverless.getProvider('kubeless');
 
     this.hooks = {
+      'before:package:createDeploymentArtifacts': () => BbPromise.bind(this)
+        .then(this.excludes),
       'deploy:deploy': () => BbPromise.bind(this)
         .then(this.validate)
         .then(this.deployFunction),
     };
     // Store the result of loading the Zip file
     this.loadZip = _.memoize(JSZip.loadAsync);
+  }
+
+  excludes() {
+    const exclude = this.serverless.service.package.exclude || [];
+    exclude.push('node_modules/**');
+    this.serverless.service.package.exclude = exclude;
   }
 
   validate() {
@@ -56,40 +63,42 @@ class KubelessDeploy {
     return BbPromise.resolve();
   }
 
-  getFunctionContent(relativePath) {
-    const pkg = this.options.package ||
-      this.serverless.service.package.path;
-    let resultPromise = null;
-    if (pkg) {
-      resultPromise = this.loadZip(fs.readFileSync(pkg)).then(
-        (zip) => zip.file(relativePath).async('string')
+  getFileContent(zipFile, relativePath) {
+    return this.loadZip(fs.readFileSync(zipFile)).then(
+      (zip) => zip.file(relativePath).async('string')
+    );
+  }
+
+  checkSize(pkg) {
+    const stat = fs.statSync(pkg);
+    // Maximum size for a etcd entry is 1 MB and right now Kubeless is storing files as
+    // etcd entries
+    const oneMB = 1024 * 1024;
+    if (stat.size > oneMB) {
+      this.serverless.cli.log(
+        `WARNING! Function zip file is ${Math.round(stat.size / oneMB)}MB. ` +
+        'The maximum size allowed is 1MB: please use package.exclude directives to include ' +
+        'only the required files'
       );
-    } else {
-      resultPromise = new BbPromise((resolve, reject) => {
-        fs.readFile(
-          path.join(this.serverless.config.servicePath || '.', relativePath),
-          (err, d) => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve(d.toString());
-            }
-          });
-      });
     }
-    return resultPromise;
   }
 
   deployFunction() {
     const runtime = this.serverless.service.provider.runtime;
     const populatedFunctions = [];
-    return new BbPromise((resolve) => {
+    return new BbPromise((resolve, reject) => {
       _.each(this.serverless.service.functions, (description, name) => {
-        if (description.handler) {
-          const files = helpers.getRuntimeFilenames(runtime, description.handler);
-          this.getFunctionContent(files.handler)
-            .then(functionContent => {
-              this.getFunctionContent(files.deps)
+        const pkg = this.options.package ||
+          this.serverless.service.package.path ||
+          description.package.artifact ||
+          this.serverless.config.serverless.service.artifact;
+        this.checkSize(pkg);
+        fs.readFile(pkg, { encoding: 'base64' }, (err, functionContent) => {
+          if (err) {
+            reject(err);
+          } else if (description.handler) {
+            const files = helpers.getRuntimeFilenames(runtime, description.handler);
+            this.getFileContent(pkg, files.deps)
                 .catch(() => {
                   // No requirements found
                 })
@@ -97,7 +106,7 @@ class KubelessDeploy {
                   populatedFunctions.push(
                     _.assign({}, description, {
                       id: name,
-                      text: functionContent,
+                      content: functionContent,
                       deps: requirementsContent,
                       image: description.image || this.serverless.service.provider.image,
                       events: _.map(description.events, (event) => {
@@ -118,13 +127,13 @@ class KubelessDeploy {
                     resolve();
                   }
                 });
-            });
-        } else {
-          populatedFunctions.push(_.assign({}, description, { id: name }));
-          if (populatedFunctions.length === _.keys(this.serverless.service.functions).length) {
-            resolve();
+          } else {
+            populatedFunctions.push(_.assign({}, description, { id: name }));
+            if (populatedFunctions.length === _.keys(this.serverless.service.functions).length) {
+              resolve();
+            }
           }
-        }
+        });
       });
     }).then(() => deploy(
       populatedFunctions,
@@ -137,6 +146,7 @@ class KubelessDeploy {
         verbose: this.options.verbose,
         log: this.serverless.cli.log.bind(this.serverless.cli),
         timeout: this.serverless.service.provider.timeout,
+        contentType: 'base64+zip',
       }
     ));
   }

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -31,6 +31,7 @@ function getFunctionDescription(
     image,
     deps,
     funcContent,
+    contentType,
     handler,
     desc,
     labels,
@@ -52,6 +53,7 @@ function getFunctionDescription(
     spec: {
       deps: deps || '',
       function: funcContent,
+      'function-content-type': contentType,
       handler,
       runtime,
       timeout: String(timeout || '180'),
@@ -300,6 +302,7 @@ function deploy(functions, runtime, options) {
     force: false,
     verbose: false,
     log: console.log,
+    contentType: 'text',
   });
   const errors = [];
   let counter = 0;
@@ -319,7 +322,8 @@ function deploy(functions, runtime, options) {
               runtime,
               description.image,
               description.deps,
-              description.text,
+              description.content,
+              options.contentType,
               description.handler,
               description.description,
               description.labels,

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -213,6 +213,8 @@ function waitForDeployment(funcName, requestMoment, namespace, options) {
                 opts.log(`Pods status: ${currentPodStatus}`);
                 previousPodStatus = currentPodStatus;
               }
+            } else if (process.exitCode === 1) {
+              reject('Failed to deploy some functions');
             }
           }
         }
@@ -254,7 +256,9 @@ function deployFunctionAndWait(body, functions, options) {
             requestMoment,
             functions.namespace,
             { verbose: opts.verbose, log: opts.log }
-        ).then(() => {
+        ).catch((waitErr) => {
+          reject(waitErr);
+        }).then(() => {
           resolve(true);
         });
       }

--- a/scripts/install-minikube.sh
+++ b/scripts/install-minikube.sh
@@ -41,7 +41,7 @@ EOF
 }
 check_or_install_minikube() {
     which minikube || {
-        wget --no-clobber -O minikube \
+        wget -q --no-clobber -O minikube \
             https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
         install_bin ./minikube
     }

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -30,19 +30,19 @@ const rm = require('./lib/rm');
 const sinon = require('sinon');
 
 const KubelessDeploy = require('../deploy/kubelessDeploy');
-const serverless = require('./lib/serverless')();
+const serverlessFact = require('./lib/serverless');
+
+let serverless = serverlessFact();
 
 require('chai').use(chaiAsPromised);
 
-function instantiateKubelessDeploy(handlerFile, depsFile, serverlessWithFunction, options) {
+function instantiateKubelessDeploy(zipFile, depsFile, serverlessWithFunction, options) {
   const kubelessDeploy = new KubelessDeploy(serverlessWithFunction, options);
   // Mock call to getFunctionContent when retrieving the function code
-  sinon.stub(kubelessDeploy, 'getFunctionContent')
-    .withArgs(path.basename(handlerFile))
-    .callsFake(() => ({ then: (f) => f(fs.readFileSync(handlerFile).toString()) }));
+  sinon.stub(kubelessDeploy, 'getFileContent');
   // Mock call to getFunctionContent when retrieving the requirements text
-  kubelessDeploy.getFunctionContent
-    .withArgs(path.basename(depsFile))
+  kubelessDeploy.getFileContent
+    .withArgs(zipFile, path.basename(depsFile))
     .callsFake(() => ({ catch: () => ({ then: (f) => {
       if (fs.existsSync(depsFile)) {
         return f(fs.readFileSync(depsFile).toString());
@@ -106,36 +106,46 @@ describe('KubelessDeploy', () => {
     let clock = null;
     let cwd = null;
     let config = null;
-    let handlerFile = null;
+    let pkgFile = null;
     let depsFile = null;
     const functionName = 'myFunction';
-    const functionText = 'function code';
+    const functionRawText = 'function code';
+    const functionText = new Buffer(functionRawText).toString('base64');
     let serverlessWithFunction = null;
 
     let kubelessDeploy = null;
 
     beforeEach(() => {
+      serverless = serverlessFact();
       cwd = path.join(os.tmpdir(), moment().valueOf().toString());
       fs.mkdirSync(cwd);
+      fs.mkdirSync(path.join(cwd, '.serverless'));
       setInterval(() => {
         clock.tick(2001);
       }, 100);
       clock = sinon.useFakeTimers();
       config = mocks.kubeConfig(cwd);
+      pkgFile = path.join(cwd, `.serverless/${functionName}.zip`);
+      fs.writeFileSync(pkgFile, functionRawText);
       serverlessWithFunction = _.defaultsDeep({}, serverless, {
-        config: {},
+        config: {
+          serverless: {
+            service: {
+              artifact: pkgFile,
+            },
+          },
+        },
         service: {
           functions: {},
         },
       });
       serverlessWithFunction.service.functions[functionName] = {
         handler: 'function.hello',
+        package: {},
       };
       serverlessWithFunction.config.servicePath = cwd;
-      handlerFile = path.join(cwd, 'function.py');
-      fs.writeFileSync(handlerFile, functionText);
       depsFile = path.join(cwd, 'requirements.txt');
-      kubelessDeploy = instantiateKubelessDeploy(handlerFile, depsFile, serverlessWithFunction);
+      kubelessDeploy = instantiateKubelessDeploy(pkgFile, depsFile, serverlessWithFunction);
     });
     afterEach(() => {
       clock.restore();
@@ -149,43 +159,42 @@ describe('KubelessDeploy', () => {
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
+        'function-content-type': 'base64+zip',
       });
       return expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()
       ).to.be.fulfilled;
     });
     it('should deploy a function (nodejs)', () => {
-      handlerFile = path.join(cwd, 'function.js');
       depsFile = path.join(cwd, 'package.json');
-      fs.writeFileSync(handlerFile, 'nodejs function code');
       fs.writeFileSync(depsFile, 'nodejs function deps');
-      kubelessDeploy = instantiateKubelessDeploy(handlerFile, depsFile, _.defaultsDeep(
+      kubelessDeploy = instantiateKubelessDeploy(pkgFile, depsFile, _.defaultsDeep(
         { service: { provider: { runtime: 'nodejs6' } } },
         serverlessWithFunction
       ));
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
         deps: 'nodejs function deps',
-        function: 'nodejs function code',
+        function: functionText,
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: 'nodejs6',
         type: 'HTTP',
+        'function-content-type': 'base64+zip',
       });
       return expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()
       ).to.be.fulfilled;
     });
     it('should deploy a function (ruby)', () => {
-      handlerFile = path.join(cwd, 'function.rb');
       depsFile = path.join(cwd, 'Gemfile');
-      fs.writeFileSync(handlerFile, 'ruby function code');
       fs.writeFileSync(depsFile, 'ruby function deps');
-      kubelessDeploy = instantiateKubelessDeploy(handlerFile, depsFile, _.defaultsDeep(
+      kubelessDeploy = instantiateKubelessDeploy(pkgFile, depsFile, _.defaultsDeep(
         { service: { provider: { runtime: 'ruby2.4' } } },
         serverlessWithFunction
       ));
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
         deps: 'ruby function deps',
-        function: 'ruby function code',
+        function: functionText,
+        'function-content-type': 'base64+zip',
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: 'ruby2.4',
         type: 'HTTP',
@@ -198,7 +207,7 @@ describe('KubelessDeploy', () => {
       const serverlessWithImage = _.cloneDeep(serverlessWithFunction);
       serverlessWithImage.service.provider.image = 'some-custom-image';
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithImage
       );
@@ -225,7 +234,7 @@ describe('KubelessDeploy', () => {
       const serverlessWithImage = _.cloneDeep(serverlessWithFunction);
       serverlessWithImage.service.functions[functionName].image = 'some-custom-image';
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithImage
       );
@@ -253,7 +262,7 @@ describe('KubelessDeploy', () => {
       serverlessWithImage.service.provider.image = 'global-custom-image';
       serverlessWithImage.service.functions[functionName].image = 'local-custom-image';
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithImage
       );
@@ -280,7 +289,7 @@ describe('KubelessDeploy', () => {
       const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomNamespace.service.provider.namespace = 'custom';
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomNamespace
       );
@@ -299,7 +308,7 @@ describe('KubelessDeploy', () => {
       const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomNamespace.service.functions.myFunction.namespace = 'custom';
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomNamespace
       );
@@ -387,6 +396,7 @@ describe('KubelessDeploy', () => {
       };
       nock(config.clusters[0].cluster.server)
         .get('/api/v1/pods')
+        .times(10)
         .reply(200, {
           items: [{
             metadata: {
@@ -400,18 +410,21 @@ describe('KubelessDeploy', () => {
             },
           }],
         });
-      kubelessDeploy.deployFunction().then(() => {
-        expect(kubelessDeploy.serverless.cli.log.lastCall.args[0]).to.be.eql(
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, funcSpec);
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction().catch(() => {
+          expect(kubelessDeploy.serverless.cli.log.lastCall.args[0]).to.be.eql(
             'ERROR: Failed to deploy the function'
           );
-        expect(process.exitCode).to.be.eql(1);
-        kubelessDeploy.serverless.cli.log.restore();
-      });
+          expect(process.exitCode).to.be.eql(1);
+        })
+      ).to.be.fulfilled;
     });
     it('should retry if it fails to retrieve pods info', () => {
       const funcSpec = {
         deps: '',
         function: functionText,
+        'function-content-type': 'base64+zip',
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
@@ -444,7 +457,7 @@ describe('KubelessDeploy', () => {
       // Second call, ready:
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, funcSpec);
       // return expect( // eslint-disable-line no-unused-expressions
-      expect(
+      return expect(
         kubelessDeploy.deployFunction()
       ).to.be.eventually.rejectedWith(
         `Unable to retrieve the status of the ${functionName} deployment`
@@ -455,6 +468,7 @@ describe('KubelessDeploy', () => {
       const funcSpec = {
         deps: '',
         function: functionText,
+        'function-content-type': 'base64+zip',
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
@@ -523,7 +537,7 @@ describe('KubelessDeploy', () => {
         trigger: 'topic',
       }];
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomNamespace
       );
@@ -546,7 +560,7 @@ describe('KubelessDeploy', () => {
         schedule: '* * * * *',
       }];
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithScheduler
       );
@@ -568,7 +582,7 @@ describe('KubelessDeploy', () => {
       const desc = 'Test Description';
       serverlessWithCustomNamespace.service.functions[functionName].description = desc;
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomNamespace
       );
@@ -589,7 +603,7 @@ describe('KubelessDeploy', () => {
       const labels = { label1: 'Test Label' };
       serverlessWithCustomNamespace.service.functions[functionName].labels = labels;
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomNamespace
       );
@@ -610,7 +624,7 @@ describe('KubelessDeploy', () => {
       const env = { VAR: 'test', OTHER_VAR: 'test2' };
       serverlessWithEnvVars.service.functions[functionName].environment = env;
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithEnvVars
       );
@@ -642,7 +656,7 @@ describe('KubelessDeploy', () => {
       ];
       serverlessWithEnvVars.service.functions[functionName].environment = env;
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithEnvVars
       );
@@ -676,7 +690,7 @@ describe('KubelessDeploy', () => {
       const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
       serverlessWithEnvVars.service.functions[functionName].memorySize = 128;
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithEnvVars
       );
@@ -706,7 +720,7 @@ describe('KubelessDeploy', () => {
       const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
       serverlessWithEnvVars.service.provider.memorySize = '128Gi';
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithEnvVars
       );
@@ -738,7 +752,7 @@ describe('KubelessDeploy', () => {
         http: { path: '/test' },
       }];
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomPath
       );
@@ -766,7 +780,7 @@ describe('KubelessDeploy', () => {
       }];
       serverlessWithCustomPath.service.provider.hostname = 'test.com';
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomPath
       );
@@ -794,7 +808,7 @@ describe('KubelessDeploy', () => {
         http: { hostname: 'test.com', path: '/test' },
       }];
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomPath
       );
@@ -821,7 +835,7 @@ describe('KubelessDeploy', () => {
         http: { hostname: 'test.com', path: '/test' },
       }];
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomPath
       );
@@ -849,7 +863,7 @@ describe('KubelessDeploy', () => {
       }];
       serverlessWithCustomPath.service.functions[functionName].namespace = 'custom';
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomPath
       );
@@ -877,7 +891,7 @@ describe('KubelessDeploy', () => {
         http: { path: 'test' },
       }];
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomPath
       );
@@ -920,53 +934,87 @@ describe('KubelessDeploy', () => {
           functions: {
             myFunction1: {
               handler: 'function.hello',
+              package: {},
             },
             myFunction2: {
               handler: 'function.hello',
+              package: {},
             },
             myFunction3: {
               handler: 'function.hello',
+              package: {},
             },
           },
         },
       });
       const functionsDeployed = [];
-      kubelessDeploy = instantiateKubelessDeploy(handlerFile, depsFile, serverlessWithFunctions);
+      kubelessDeploy = instantiateKubelessDeploy(pkgFile, depsFile, serverlessWithFunctions);
       const funcSpec = {
         deps: '',
         function: functionText,
+        'function-content-type': 'base64+zip',
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
+        timeout: '180',
       };
       const postReply = (uri, req) => {
         functionsDeployed.push(req.metadata.name);
+        return JSON.stringify(req);
       };
+      nock(config.clusters[0].cluster.server)
+        .persist()
+        .get('/api/v1/pods')
+        .reply(200, () => ({
+          items: [
+            {
+              metadata: {
+                name: 'myFunction3',
+                labels: { function: 'myFunction3' },
+                creationTimestamp: moment().add('60', 's'),
+              },
+              spec: funcSpec,
+              status: {
+                containerStatuses: [{ ready: true, restartCount: 0 }],
+              },
+            },
+            {
+              metadata: {
+                name: 'myFunction1',
+                labels: { function: 'myFunction1' },
+                creationTimestamp: moment().add('60', 's'),
+              },
+              spec: funcSpec,
+              status: {
+                containerStatuses: [{ ready: true, restartCount: 0 }],
+              },
+            }],
+        }));
+
       // Call for myFunction1
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, 'myFunction1', funcSpec, {
         postReply,
       });
       // Call for myFunction2
       nock(config.clusters[0].cluster.server)
-        .post('/apis/k8s.io/v1/namespaces/default/functions', {
+        .post('/apis/k8s.io/v1/namespaces/default/functions/', {
           apiVersion: 'k8s.io/v1',
           kind: 'Function',
           metadata: { name: 'myFunction2', namespace: 'default' },
           spec: funcSpec,
         })
-        .reply(500, 'Internal server error');
+        .replyWithError({ message: 'Internal server error', code: 500 });
       // Call for myFunction3
       nock(config.clusters[0].cluster.server)
-        .post('/apis/k8s.io/v1/namespaces/default/functions', {
+        .post('/apis/k8s.io/v1/namespaces/default/functions/', {
           apiVersion: 'k8s.io/v1',
           kind: 'Function',
           metadata: { name: 'myFunction3', namespace: 'default' },
           spec: funcSpec,
         })
         .reply(200, postReply);
-
-      kubelessDeploy.deployFunction().catch(e => {
-        expect(e).to.be.eql(
+      return kubelessDeploy.deployFunction().catch(e => {
+        expect(e.message).to.be.eql(
           'Found errors while deploying the given functions:\n' +
           'Error: Unable to deploy the function myFunction2. Received:\n' +
           '  Code: 500\n' +
@@ -980,20 +1028,12 @@ describe('KubelessDeploy', () => {
       kubelessDeploy = new KubelessDeploy(serverlessWithFunction, {
         package: path.join(cwd, 'package.zip'),
       });
-      fs.writeFileSync(path.join(path.join(cwd, 'package.zip')), '');
-      sinon.stub(kubelessDeploy, 'loadZip').returns({
-        then: (f) => f({
-          file: () => ({
-            async: () => ({
-              then: (ff) => ff('different function content'),
-              catch: () => ({ then: (ff) => ff(null) }),
-            }),
-          }),
-        }),
-      });
+      const content = 'different function content';
+      const contentBase64 = new Buffer(content).toString('base64');
+      fs.writeFileSync(path.join(path.join(cwd, 'package.zip')), content);
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
         deps: '',
-        function: 'different function content',
+        function: contentBase64,
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
@@ -1003,11 +1043,12 @@ describe('KubelessDeploy', () => {
       ).to.be.fulfilled;
     });
     it('should deploy a function with requirements', () => {
-      kubelessDeploy = new KubelessDeploy(serverlessWithFunction);
       fs.writeFileSync(depsFile, 'request');
+      kubelessDeploy = instantiateKubelessDeploy(pkgFile, depsFile, serverlessWithFunction);
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
         deps: 'request',
-        function: 'function code',
+        function: functionText,
+        'function-content-type': 'base64+zip',
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
@@ -1022,12 +1063,13 @@ describe('KubelessDeploy', () => {
       kubelessDeploy = new KubelessDeploy(serverlessWithFunction, {
         package: path.join(cwd, 'package.zip'),
       });
-      fs.writeFileSync(path.join(path.join(cwd, 'package.zip')), '');
+      const content = 'different function content';
+      const contentBase64 = new Buffer(content).toString('base64');
+      fs.writeFileSync(path.join(path.join(cwd, 'package.zip')), content);
       sinon.stub(kubelessDeploy, 'loadZip').returns({
         then: (f) => f({
           file: () => ({
             async: () => ({
-              then: (ff) => ff('different function content'),
               catch: () => ({ then: (ff) => ff('request') }),
             }),
           }),
@@ -1035,7 +1077,7 @@ describe('KubelessDeploy', () => {
       });
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
         deps: 'request',
-        function: 'different function content',
+        function: contentBase64,
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
@@ -1045,10 +1087,10 @@ describe('KubelessDeploy', () => {
       ).to.be.fulfilled;
     });
     it('should redeploy a function', () => {
-      fs.writeFileSync(handlerFile, 'function code modified');
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
-        deps: 'request',
-        function: 'function code modified',
+        deps: '',
+        function: functionText,
+        'function-content-type': 'base64+zip',
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
@@ -1059,7 +1101,7 @@ describe('KubelessDeploy', () => {
             labels: { function: functionName },
           },
           spec: {
-            deps: 'request',
+            deps: '',
             function: 'function code',
             handler: serverlessWithFunction.service.functions[functionName].handler,
             runtime: serverlessWithFunction.service.provider.runtime,
@@ -1074,7 +1116,8 @@ describe('KubelessDeploy', () => {
           metadata: { name: 'myFunction', namespace: 'default' },
           spec: {
             deps: '',
-            function: 'function code modified',
+            function: functionText,
+            'function-content-type': 'base64+zip',
             handler: 'function.hello',
             runtime: 'python2.7',
             type: 'HTTP',
@@ -1096,10 +1139,10 @@ describe('KubelessDeploy', () => {
       return result;
     });
     it('should fail if a redeployment returns an error code', () => {
-      fs.writeFileSync(handlerFile, 'function code modified');
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
         deps: 'request',
-        function: 'function code modified',
+        function: functionText,
+        'function-content-type': 'base64+zip',
         handler: serverlessWithFunction.service.functions[functionName].handler,
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
@@ -1125,7 +1168,8 @@ describe('KubelessDeploy', () => {
           metadata: { name: 'myFunction', namespace: 'default' },
           spec: {
             deps: '',
-            function: 'function code modified',
+            function: functionText,
+            'function-content-type': 'base64+zip',
             handler: 'function.hello',
             runtime: 'python2.7',
             type: 'HTTP',
@@ -1146,7 +1190,7 @@ describe('KubelessDeploy', () => {
       const serverlessWithCustomProperties = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomProperties.service.functions[functionName].timeout = 10;
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomProperties
       );
@@ -1167,7 +1211,7 @@ describe('KubelessDeploy', () => {
       const serverlessWithCustomProperties = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomProperties.service.provider.timeout = 10;
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomProperties
       );
@@ -1188,7 +1232,7 @@ describe('KubelessDeploy', () => {
       const serverlessWithCustomProperties = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomProperties.service.functions[functionName].port = 1234;
       kubelessDeploy = instantiateKubelessDeploy(
-        handlerFile,
+        pkgFile,
         depsFile,
         serverlessWithCustomProperties
       );

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -97,7 +97,7 @@ function createDeploymentNocks(endpoint, func, funcSpec, options) {
     existingFunctions: [],
     description: null,
     labels: null,
-    postReply: 'OK',
+    postReply: { message: 'OK' },
   });
   const postBody = {
     apiVersion: 'k8s.io/v1',
@@ -119,7 +119,7 @@ function createDeploymentNocks(endpoint, func, funcSpec, options) {
     .reply(200, JSON.stringify({ items: opts.existingFunctions }));
   nock(endpoint)
     .post(`/apis/k8s.io/v1/namespaces/${opts.namespace}/functions/`, postBody)
-    .reply(200, JSON.stringify(opts.postReply));
+    .reply(200, opts.postReply);
   nock(endpoint)
     .persist()
     .get('/api/v1/pods')
@@ -163,7 +163,7 @@ function createIngressNocks(endpoint, func, hostname, p, options) {
         }],
       },
     })
-    .reply(200, 'OK');
+    .reply(200, { message: 'OK' });
 }
 
 module.exports = {


### PR DESCRIPTION
Kubeless now support to use Zip files to upload functions. This PR adapts this plugin to use the serverless packaged file instead of using standalone code files. 

This PR includes a **breaking change**. By default we are omitting the `node_modules` folder but even if without that folder the Zip file is bigger than 1MB the deployment will fail. It is necessary to use the [`package.exclude`](https://serverless.com/framework/docs/providers/aws/guide/packaging/#exclude--include)  syntax in order to avoid it.