### PR TITLE
Allow to change DNS resolution from nip.io

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -132,6 +132,7 @@ class KubelessDeploy {
       {
         namespace: this.serverless.service.provider.namespace,
         hostname: this.serverless.service.provider.hostname,
+        defaultDNSResolution: this.serverless.service.provider.defaultDNSResolution,
         memorySize: this.serverless.service.provider.memorySize,
         force: this.options.force,
         verbose: this.options.verbose,

--- a/examples/http-custom-path/README.md
+++ b/examples/http-custom-path/README.md
@@ -41,6 +41,8 @@ Trigger:  HTTP
 Dependencies:
 ```
 
+Note that if you don't specify a hostname in your `serverless.yaml` it will be configured to use a DNS resolutor like [`nip.io`](http://nip.io) setting the property `defaultDNSResolution` in the provider section. You can also change the default DNS resolutor to a different service like [`xip.io`](http//xip.io).
+
 Depending on the Ingress configuration the URL may be redirected to use the HTTPS protocol. You can call your function with a browser or executing:
 ```console
 $ curl 192.168.99.100.nip.io/hello

--- a/examples/http-custom-path/README.md
+++ b/examples/http-custom-path/README.md
@@ -41,7 +41,7 @@ Trigger:  HTTP
 Dependencies:
 ```
 
-Note that if you don't specify a hostname in your `serverless.yaml` it will be configured to use a DNS resolutor like [`nip.io`](http://nip.io) setting the property `defaultDNSResolution` in the provider section. You can also change the default DNS resolutor to a different service like [`xip.io`](http//xip.io).
+Note that if you don't specify a hostname in your `serverless.yaml` it will be configured to use a DNS service like [`nip.io`](http://nip.io) setting the property `defaultDNSResolution` in the provider section. You can also change the default DNS resolutor to a different service like [`xip.io`](http//xip.io).
 
 Depending on the Ingress configuration the URL may be redirected to use the HTTPS protocol. You can call your function with a browser or executing:
 ```console

--- a/examples/http-custom-path/serverless.yml
+++ b/examples/http-custom-path/serverless.yml
@@ -3,6 +3,7 @@ service: hello-http
 provider:
   name: kubeless
   runtime: python2.7
+  defaultDNSResolution: 'xip.io'
 
 plugins:
   - serverless-kubeless

--- a/examples/todo-app/backend/serverless.yml
+++ b/examples/todo-app/backend/serverless.yml
@@ -3,6 +3,7 @@ service: todos
 provider:
   name: kubeless
   runtime: nodejs6
+  defaultDNSResolution: 'xip.io'
 
 plugins:
   - serverless-kubeless

--- a/examples/todo-app/backend/serverless.yml
+++ b/examples/todo-app/backend/serverless.yml
@@ -3,7 +3,6 @@ service: todos
 provider:
   name: kubeless
   runtime: nodejs6
-  defaultDNSResolution: 'xip.io'
 
 plugins:
   - serverless-kubeless

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -383,6 +383,7 @@ function deploy(functions, runtime, options) {
                       verbose: opts.verbose,
                       log: opts.log,
                       hostname: opts.hostname,
+                      defaultDNSResolution: opts.defaultDNSResolution,
                       namespace: functionsApi.namespace,
                     });
                     p.catch(ingressErr => {

--- a/lib/ingress.js
+++ b/lib/ingress.js
@@ -37,12 +37,14 @@ function addIngressRuleIfNecessary(functions, options) {
     log: console.log,
     namespace: 'default',
     hostname: null,
+    defaultDNSResolution: 'nip.io',
   });
   const config = helpers.loadKubeConfig();
   const extensions = new Api.Extensions(helpers.getConnectionOptions(
     config, { namespace: options.namespace })
   );
-  const defaultHostname = `${url.parse(helpers.getKubernetesAPIURL(config)).hostname}.nip.io`;
+  const defaultHostname =
+    `${url.parse(helpers.getKubernetesAPIURL(config)).hostname}.${opts.defaultDNSResolution}`;
   const rules = [];
   _.each(functions, (description) => {
     _.each(description.events, event => {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -898,6 +898,34 @@ describe('KubelessDeploy', () => {
         kubelessDeploy.deployFunction()
       ).to.be.fulfilled;
     });
+    it('should deploy a function in a specific path (with a different DNS resolution)', () => {
+      const serverlessWithCustomPath = _.cloneDeep(serverlessWithFunction);
+      serverlessWithCustomPath.service.provider.defaultDNSResolution = 'xip.io';
+      serverlessWithCustomPath.service.functions[functionName].events = [{
+        http: { path: '/test' },
+      }];
+      kubelessDeploy = instantiateKubelessDeploy(
+        handlerFile,
+        depsFile,
+        serverlessWithCustomPath
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, {
+        deps: '',
+        function: functionText,
+        handler: serverlessWithFunction.service.functions[functionName].handler,
+        runtime: serverlessWithFunction.service.provider.runtime,
+        type: 'HTTP',
+      });
+      mocks.createIngressNocks(
+        config.clusters[0].cluster.server,
+        functionName,
+        '1.2.3.4.xip.io',
+        '/test'
+      );
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
     it('should fail if a deployment returns an error code', () => {
       nock(config.clusters[0].cluster.server)
         .get('/apis/k8s.io/v1/namespaces/default/functions/')


### PR DESCRIPTION
`nip.io` is currently down, causing the integration tests to fail. We should not force to use that choice for all the functions so this PR allows to change that.

I changed the DNS resolution from `nip.io` to `xip.io` in the existing examples so we fix integration tests.