### PR TITLE
Add Secrets support

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -80,7 +80,7 @@ function getFunctionDescription(
   if (labels) {
     funcs.metadata.labels = labels;
   }
-  if (image || env || memory) {
+  if (image || env || memory || secrets) {
     const container = {
       name: funcName,
     };

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -114,19 +114,19 @@ function getFunctionDescription(
     funcs.spec.template = {
       spec: { containers: [container] },
     };
-      if (secrets !== undefined && secrets.length > 0) {
-          if (container.volumeMounts === undefined) {
-              container.volumeMounts = [];
-          }
-          if (funcs.spec.template.spec.volumes === undefined) {
-              funcs.spec.template.spec.volumes = [];
-          }
-          secrets.forEach(secret => {
-              container.volumeMounts.push({name: `${secret}-vol`, mountPath: `/${secret}`});
-              funcs.spec.template.spec.volumes
-                  .push({name: `${secret}-vol`, secret: {secretName: secret}});
-          });
+    if (secrets !== undefined && secrets.length > 0) {
+      if (container.volumeMounts === undefined) {
+        container.volumeMounts = [];
       }
+      if (funcs.spec.template.spec.volumes === undefined) {
+        funcs.spec.template.spec.volumes = [];
+      }
+      secrets.forEach(secret => {
+        container.volumeMounts.push({ name: `${secret}-vol`, mountPath: `/${secret}` });
+        funcs.spec.template.spec.volumes
+          .push({ name: `${secret}-vol`, secret: { secretName: secret } });
+      });
+    }
   }
   switch (eventType) {
     case 'http':

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -41,7 +41,8 @@ function getFunctionDescription(
     eventTrigger,
     eventSchedule,
     timeout,
-    port
+    port,
+    secrets
 ) {
   const funcs = {
     apiVersion: 'k8s.io/v1',
@@ -113,6 +114,19 @@ function getFunctionDescription(
     funcs.spec.template = {
       spec: { containers: [container] },
     };
+      if (secrets !== undefined && secrets.length > 0) {
+          if (container.volumeMounts === undefined) {
+              container.volumeMounts = [];
+          }
+          if (funcs.spec.template.spec.volumes === undefined) {
+              funcs.spec.template.spec.volumes = [];
+          }
+          secrets.forEach(secret => {
+              container.volumeMounts.push({name: `${secret}-vol`, mountPath: `/${secret}`});
+              funcs.spec.template.spec.volumes
+                  .push({name: `${secret}-vol`, secret: {secretName: secret}});
+          });
+      }
   }
   switch (eventType) {
     case 'http':
@@ -337,7 +351,8 @@ function deploy(functions, runtime, options) {
               event.trigger,
               event.schedule,
               description.timeout || opts.timeout,
-              description.port
+              description.port,
+              description.secrets
           );
           let deploymentPromise = null;
           let redeployed = false;

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -338,20 +338,20 @@ describe('KubelessDeploy', () => {
         runtime: serverlessWithFunction.service.provider.runtime,
         type: 'HTTP',
       }, {
-          deps: '',
-          function: functionText,
-          handler: serverlessWithFunction.service.functions[functionName].handler,
-          runtime: serverlessWithFunction.service.provider.runtime,
-          type: 'HTTP',
-          template: {
-              spec: {
-                  containers: [{
-                      name: functionName,
-                      volumeMounts: [{ name: 'secret1-vol', mountPath: '/secret1'}]
-                  }],
-                  volumes: [ {name: 'secret1-vol', secret: {secretName: 'secret1'}}]
-              },
+        deps: '',
+        function: functionText,
+        handler: serverlessWithFunction.service.functions[functionName].handler,
+        runtime: serverlessWithFunction.service.provider.runtime,
+        type: 'HTTP',
+        template: {
+          spec: {
+            containers: [{
+              name: functionName,
+              volumeMounts: [{ name: 'secret1-vol', mountPath: '/secret1' }],
+            }],
+            volumes: [{ name: 'secret1-vol', secret: { secretName: 'secret1' } }],
           },
+        },
       });
       return expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()


### PR DESCRIPTION
In case you want to add some secrets to your kubeless function [PR 572](https://github.com/kubeless/kubeless/pull/572) you can specify them as list of secret names in a function description.
```functions:
  test:
    handler: handler.test
    namespace: kubeles
    secrets:
    - experiment
```