### PR TITLE
case sensitive 'Kind' key

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -44,7 +44,7 @@ function getFunctionDescription(
 ) {
   const funcs = {
     apiVersion: 'kubeless.io/v1beta1',
-    kind: 'Function',
+    Kind: 'Function',
     metadata: {
       name: funcName,
       namespace,


### PR DESCRIPTION
That is really strange. But today after upgrade kubeless to version 0.6.0 `serverless deploy` started to fail with error:
```Message: Object 'Kind' is missing in '{"object":{"apiVersion":"kubeless.io/v1beta1","kind":"Function","metada```
After I've renamed key from `kind` to `Kind` it back to normal again. Can you please help me to understand is it a right fix or the problem is somewhere else. We use kubernetes versions 
```kubectl version
Client Version: version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.0", GitCommit:"925c127ec6b946659ad0fd596fa959be43f0cc05", GitTreeState:"clean", BuildDate:"2017-12-15T21:07:38Z", GoVersion:"go1.9.2", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"7", GitVersion:"v1.7.16", GitCommit:"e8846c1d7e7e632d4bd5ed46160eff3dc4c993c5", GitTreeState:"clean", BuildDate:"2018-04-04T08:47:13Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
```