### PR TITLE
Parse labels as strings

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -24,6 +24,22 @@ const helpers = require('./helpers');
 const ingressHelper = require('./ingress');
 const moment = require('moment');
 
+function forceString(obj) {
+  const result = {};
+  _.each(obj, (v, k) => {
+    if (v === null) {
+      result[k] = 'null';
+    } else if (v === undefined) {
+      result[k] = 'undefined';
+    } else if (typeof v === 'object') {
+      result[k] = JSON.stringify(v);
+    } else {
+      result[k] = v.toString();
+    }
+  });
+  return result;
+}
+
 function getFunctionDescription(
     funcName,
     namespace,
@@ -48,10 +64,10 @@ function getFunctionDescription(
     metadata: {
       name: funcName,
       namespace,
-      labels: _.assign({}, labels, {
+      labels: forceString(_.assign({}, labels, {
         'created-by': 'kubeless',
         function: funcName,
-      }),
+      })),
     },
     spec: {
       deps: deps || '',
@@ -68,9 +84,9 @@ function getFunctionDescription(
           protocol: 'TCP',
           targetPort: Number(port || 8080),
         }],
-        selector: _.assign({}, labels, {
+        selector: {
           function: funcName,
-        }),
+        },
         type: 'ClusterIP',
       },
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/examples-test.js
+++ b/test/examples-test.js
@@ -532,7 +532,7 @@ describe('Examples', () => {
                         if (stdout.match(/mongodb-.*Running/)) {
                           exec('kubectl logs -l io.kompose.service=mongodb', (lerr, logs) => {
                             if (lerr) throw lerr;
-                            if (logs.match(/waiting for connections on port 27017/)) {
+                            if (logs.match(/Starting mongod/)) {
                               clearInterval(wait);
                               exec(
                                 'serverless info',

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -592,7 +592,22 @@ describe('KubelessDeploy', () => {
     });
     it('should deploy a function with labels', () => {
       const serverlessWithCustomNamespace = _.cloneDeep(serverlessWithFunction);
-      const labels = { label1: 'Test Label' };
+      const labels = {
+        label1: 'Test Label',
+        label2: false,
+        label3: null,
+        label4: undefined,
+        label5: 1,
+        label6: { a: 1 },
+      };
+      const sLabels = {
+        label1: 'Test Label',
+        label2: 'false',
+        label3: 'null',
+        label4: 'undefined',
+        label5: '1',
+        label6: '{"a":1}',
+      };
       serverlessWithCustomNamespace.service.functions[functionName].labels = labels;
       kubelessDeploy = instantiateKubelessDeploy(
         pkgFile,
@@ -600,7 +615,7 @@ describe('KubelessDeploy', () => {
         serverlessWithCustomNamespace
       );
       mocks.createDeploymentNocks(
-        config.clusters[0].cluster.server, functionName, defaultFuncSpec(), { labels });
+        config.clusters[0].cluster.server, functionName, defaultFuncSpec(), { labels: sLabels });
       const result = expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()
       ).to.be.fulfilled;

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -118,7 +118,7 @@ function createDeploymentNocks(endpoint, func, funcSpec, options) {
     };
   }
   if (opts.labels) {
-    postBody.spec.service.selector = _.assign(postBody.spec.service.selector, opts.labels);
+    postBody.spec.service.selector = _.assign(postBody.spec.service.selector);
   }
   nock(endpoint)
     .persist()


### PR DESCRIPTION
Ref: https://github.com/serverless/serverless-kubeless/issues/85#issuecomment-390550917

Use always string as labels. Limit function selector to just the function name.