### PR TITLE
Adds support for `enableTLSAcme`

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -147,6 +147,7 @@ class KubelessDeploy {
       {
         namespace: this.serverless.service.provider.namespace,
         hostname: this.serverless.service.provider.hostname,
+        enableTLSAcme: this.serverless.service.provider.enableTLSAcme || false,
         defaultDNSResolution: this.serverless.service.provider.defaultDNSResolution,
         memorySize: this.serverless.service.provider.memorySize,
         force: this.options.force,

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -392,8 +392,7 @@ function deployFunction(f, namespace, runtime, contentType, options) {
     f.memorySize || options.memorySize,
     f.timeout || options.timeout,
     f.port,
-    f.secrets,
-    options.enableTLSAcme
+    f.secrets
   );
   return functionsApi.getItem(funcs.metadata.name).then((res) => {
     if (res.code === 404) {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -392,7 +392,8 @@ function deployFunction(f, namespace, runtime, contentType, options) {
     f.memorySize || options.memorySize,
     f.timeout || options.timeout,
     f.port,
-    f.secrets
+    f.secrets,
+    options.enableTLSAcme
   );
   return functionsApi.getItem(funcs.metadata.name).then((res) => {
     if (res.code === 404) {
@@ -459,6 +460,7 @@ function deploy(functions, runtime, service, options) {
     verbose: false,
     log: console.log,
     contentType: 'text',
+    enableTLSAcme: false,
   });
   const errors = [];
   let counter = 0;
@@ -483,6 +485,7 @@ function deploy(functions, runtime, service, options) {
                 hostname: options.hostname,
                 defaultDNSResolution: options.defaultDNSResolution,
                 namespace: ns,
+                enableTLSAcme: options.enableTLSAcme,
               }),
             });
           });
@@ -501,6 +504,7 @@ function deploy(functions, runtime, service, options) {
                   hostname: options.hostname,
                   defaultDNSResolution: options.defaultDNSResolution,
                   namespace: ns,
+                  enableTLSAcme: options.enableTLSAcme,
                 }),
               });
             });

--- a/lib/ingress.js
+++ b/lib/ingress.js
@@ -29,6 +29,7 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
     namespace: 'default',
     hostname: null,
     defaultDNSResolution: 'nip.io',
+    enableTLSAcme: false,
   });
   const config = helpers.loadKubeConfig();
   const extensions = new Api.Extensions(helpers.getConnectionOptions(
@@ -70,14 +71,19 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
   return new BbPromise((resolve, reject) => {
     if (!_.isEmpty(rules)) {
       // Found a path to deploy the function
+      const annotations = {
+        'kubernetes.io/ingress.class': 'nginx',
+        'nginx.ingress.kubernetes.io/rewrite-target': '/',
+      };
+      if (opts.enableTLSAcme) {
+        annotations['kubernetes.io/tls-acme'] = "true";
+        annotations['nginx.ingress.kubernetes.io/ssl-redirect'] = "true";
+      }
       const ingressDef = {
         kind: 'Ingress',
         metadata: {
           name: ruleName,
-          annotations: {
-            'kubernetes.io/ingress.class': 'nginx',
-            'nginx.ingress.kubernetes.io/rewrite-target': '/',
-          },
+          annotations,
         },
         spec: { rules },
       };


### PR DESCRIPTION
Adds support for placing `enableTLSAcme: true` at the provider level of a service to get the auto-ssl certificates from cert-manager.