### PR TITLE
Allow setting a custom ingress controller

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -148,6 +148,7 @@ class KubelessDeploy {
         namespace: this.serverless.service.provider.namespace,
         hostname: this.serverless.service.provider.hostname,
         defaultDNSResolution: this.serverless.service.provider.defaultDNSResolution,
+        ingress: this.serverless.service.provider.ingress,
         memorySize: this.serverless.service.provider.memorySize,
         force: this.options.force,
         verbose: this.options.verbose,

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -482,6 +482,7 @@ function deploy(functions, runtime, service, options) {
                 log: options.log,
                 hostname: options.hostname,
                 defaultDNSResolution: options.defaultDNSResolution,
+                ingress: options.ingress,
                 namespace: ns,
               }),
             });
@@ -500,6 +501,7 @@ function deploy(functions, runtime, service, options) {
                   log: options.log,
                   hostname: options.hostname,
                   defaultDNSResolution: options.defaultDNSResolution,
+                  ingress: options.ingress,
                   namespace: ns,
                 }),
               });

--- a/lib/ingress.js
+++ b/lib/ingress.js
@@ -29,6 +29,9 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
     namespace: 'default',
     hostname: null,
     defaultDNSResolution: 'nip.io',
+    ingress: _.defaults({
+      class: 'nginx',
+    }),
   });
   const config = helpers.loadKubeConfig();
   const extensions = new Api.Extensions(helpers.getConnectionOptions(
@@ -75,8 +78,8 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
         metadata: {
           name: ruleName,
           annotations: {
-            'kubernetes.io/ingress.class': 'nginx',
-            'nginx.ingress.kubernetes.io/rewrite-target': '/',
+            'kubernetes.io/ingress.class': opts.ingress.class,
+            [`${opts.ingress.class}.ingress.kubernetes.io/rewrite-target`]: '/',
           },
         },
         spec: { rules },


### PR DESCRIPTION
Adds super basic support for setting the ingress controller used to something other than `nginx` (we're using traefik)

This was discussed a little in #114. 
