### PR TITLE
Use latest proxy endpoint

### DIFF
--- a/lib/invoke.js
+++ b/lib/invoke.js
@@ -127,7 +127,7 @@ function invoke(func, data, funcsDesc, options) {
           opts.log(`Not found any information about the function "${func}"`);
         }
         const port = functionService.spec.ports[0].name || functionService.spec.ports[0].port;
-        const url = `${APIRootUrl}/api/v1/proxy/namespaces/${namespace}/services/${func}:${port}/`;
+        const url = `${APIRootUrl}/api/v1/namespaces/${namespace}/services/${func}:${port}/proxy/`;
         const invokeConnectionOptions = Object.assign(
         connectionOptions, {
           url,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,7 +7,7 @@ function get_version {
 
 function check_tag {
   local tag=$1
-  published_tags=`curl -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME/tags`
+  published_tags=`curl -H "Authorization: token $ACCESS_TOKEN" -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME/tags`
   already_published=`echo $published_tags | jq ".[] | select(.name == \"$tag\")"`
   echo $already_published
 }
@@ -15,7 +15,7 @@ function check_tag {
 function release_tag {
   local tag=$1
   git fetch --tags
-  local last_tag=`curl -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME/tags | jq --raw-output '.[0].name'`
+  local last_tag=`curl -H "Authorization: token $ACCESS_TOKEN" -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME/tags | jq --raw-output '.[0].name'`
   local release_notes=`git log $last_tag..HEAD --oneline`
   local parsed_release_notes=$(echo "$release_notes" | sed -n -e 'H;${x;s/\n/\\n   - /g;s/^\\n//;p;}')
   parsed_release_notes=`echo "$parsed_release_notes" | sed -e '${s/  \( - [^ ]* Merge pull request\)/\1/g;}'`
@@ -42,7 +42,7 @@ if [[ -z "$ACCESS_TOKEN" ]]; then
   exit 1
 fi
 
-repo_check=`curl -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME`
+repo_check=`curl -H "Authorization: token $ACCESS_TOKEN" -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME`
 if [[ $repo_check == *"Not Found"* ]]; then
   echo "Not found a Github repository for $REPO_DOMAIN/$REPO_NAME, it is not possible to publish it" > /dev/stderr
   exit 1
@@ -52,7 +52,7 @@ else
   if [[ -z $already_published ]]; then
     echo "Releasing $tag in Github"
     release_id=`release_tag $tag`
-    if [ "$release_id" == "null" ]; then
+    if [ "$release_id" == "null" ]; then 
       echo "There was an error trying to release $tag" > /dev/stderr
       exit 1
     else

--- a/test/kubelessInvoke.test.js
+++ b/test/kubelessInvoke.test.js
@@ -153,7 +153,7 @@ describe('KubelessInvoke', () => {
             request.get.firstCall.args[0]
           ).to.contain.keys(['ca', 'auth', 'url']);
         expect(request.get.firstCall.args[0].url).to.be.eql(
-            `${kubeApiURL}/api/v1/proxy/namespaces/default/services/my-function:8080/`
+          `${kubeApiURL}/api/v1/namespaces/default/services/my-function:8080/proxy/`
           );
       });
     });
@@ -178,7 +178,7 @@ describe('KubelessInvoke', () => {
         request.post.firstCall.args[0]
       ).to.contain.keys(['url', 'body']);
         expect(request.post.firstCall.args[0].url).to.be.eql(
-        `${kubeApiURL}/api/v1/proxy/namespaces/default/services/my-function:8080/`
+          `${kubeApiURL}/api/v1/namespaces/default/services/my-function:8080/proxy/`
       );
         expect(request.post.firstCall.args[0].body).to.be.eql('hello');
       });
@@ -204,7 +204,7 @@ describe('KubelessInvoke', () => {
         request.post.firstCall.args[0]
       ).to.contain.keys(['url', 'json', 'body']);
         expect(request.post.firstCall.args[0].url).to.be.eql(
-        `${kubeApiURL}/api/v1/proxy/namespaces/default/services/my-function:8080/`
+          `${kubeApiURL}/api/v1/namespaces/default/services/my-function:8080/proxy/`
       );
         expect(request.post.firstCall.args[0].json).to.be.eql(true);
         expect(request.post.firstCall.args[0].body).to.be.eql('{"test": 1}');
@@ -241,7 +241,7 @@ describe('KubelessInvoke', () => {
           statusMessage: 'OK',
         });
         expect(request.get.firstCall.args[0].url).to.be.eql(
-        `${kubeApiURL}/api/v1/proxy/namespaces/test/services/my-function:8080/`
+          `${kubeApiURL}/api/v1/namespaces/test/services/my-function:8080/proxy/`
       );
       });
     });
@@ -264,7 +264,7 @@ describe('KubelessInvoke', () => {
           statusMessage: 'OK',
         });
         expect(request.get.firstCall.args[0].url).to.be.eql(
-        `${kubeApiURL}/api/v1/proxy/namespaces/test/services/my-function:8080/`
+          `${kubeApiURL}/api/v1/namespaces/test/services/my-function:8080/proxy/`
       );
       });
     });
@@ -312,15 +312,15 @@ describe('KubelessInvoke', () => {
         });
         expect(request.post.callCount).to.be.eql(3);
         expect(request.post.firstCall.args[0].url).to.be.eql(
-          `${kubeApiURL}/api/v1/proxy/namespaces/default/services/func1:8080/`
+          `${kubeApiURL}/api/v1/namespaces/default/services/func1:8080/proxy/`
         );
         expect(request.post.firstCall.args[0].body).to.be.eql('hello');
         expect(request.post.secondCall.args[0].url).to.be.eql(
-          `${kubeApiURL}/api/v1/proxy/namespaces/default/services/func2:8080/`
+          `${kubeApiURL}/api/v1/namespaces/default/services/func2:8080/proxy/`
         );
         expect(request.post.secondCall.args[0].body).to.be.eql('a');
         expect(request.post.thirdCall.args[0].url).to.be.eql(
-          `${kubeApiURL}/api/v1/proxy/namespaces/default/services/func3:8080/`
+          `${kubeApiURL}/api/v1/namespaces/default/services/func3:8080/proxy/`
         );
         expect(request.post.thirdCall.args[0].body).to.be.eql('b');
       });


### PR DESCRIPTION
Ref #132 

Since Kubernetes +1.10 the URL of the `proxy` subresource should be specified after the name (and port) of the service.

(This PR also contains unrelated changes to the release script).