### PR TITLE
Allow overriding k8s config context

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -49,6 +49,10 @@ function loadKubeConfig() {
   return config;
 }
 
+function getContextName(config) {
+  return process.env.KUBECONTEXT || config['current-context'];
+}
+
 function getContextInfo(config, context) {
   const contextInfo = _.find(config.contexts, c => c.name === context);
   if (!contextInfo) {
@@ -76,7 +80,7 @@ function getUserInfo(config, context) {
 }
 
 function getKubernetesAPIURL(config) {
-  const currentContext = config['current-context'];
+  const currentContext = getContextName(config);
   const clusterInfo = getClusterInfo(config, currentContext);
   // Remove trailing '/' of the URL in case it exists
   let clusterURL = clusterInfo.cluster.server.replace(/\/$/, '');
@@ -116,12 +120,12 @@ function getToken(userInfo) {
 }
 
 function getDefaultNamespace(config) {
-  const currentContext = config['current-context'];
+  const currentContext = getContextName(config);
   return getContextInfo(config, currentContext).namespace || 'default';
 }
 
 function getConnectionOptions(config, modif) {
-  const currentContext = config['current-context'];
+  const currentContext = getContextName(config);
   const userInfo = getUserInfo(config, currentContext);
   const clusterInfo = getClusterInfo(config, currentContext);
 


### PR DESCRIPTION
This is required for proper CI integration, as running `kubectl config use-context <blah> && serverless deploy` can potentially lead to race conditions between concurrent deployments.