### PR TITLE
Allow setting per-function annotations

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -52,6 +52,7 @@ function getFunctionDescription(
     handler,
     desc,
     labels,
+    annotations,
     env,
     memory,
     timeout,
@@ -68,6 +69,7 @@ function getFunctionDescription(
         'created-by': 'kubeless',
         function: funcName,
       })),
+      annotations: annotations || {},
     },
     spec: {
       deps: deps || '',
@@ -92,9 +94,7 @@ function getFunctionDescription(
     },
   };
   if (desc) {
-    funcs.metadata.annotations = {
-      'kubeless.serverless.com/description': desc,
-    };
+    funcs.metadata.annotations['kubeless.serverless.com/description'] = desc;
   }
   if (image || env || memory || secrets) {
     const container = {
@@ -388,6 +388,7 @@ function deployFunction(f, namespace, runtime, contentType, options) {
     f.handler,
     f.description,
     f.labels,
+    f.annotations,
     f.environment,
     f.memorySize || options.memorySize,
     f.timeout || options.timeout,

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -961,6 +961,7 @@ describe('KubelessDeploy', () => {
               metadata: {
                 name: 'myFunction3',
                 labels: { function: 'myFunction3' },
+                annotations: {},
                 creationTimestamp: moment().add('60', 's'),
               },
               spec: funcSpec,
@@ -972,6 +973,7 @@ describe('KubelessDeploy', () => {
               metadata: {
                 name: functionName,
                 labels: { function: functionName },
+                annotations: {},
                 creationTimestamp: moment().add('60', 's'),
               },
               spec: funcSpec,
@@ -999,6 +1001,7 @@ describe('KubelessDeploy', () => {
             name: 'myFunction2',
             namespace: 'default',
             labels: { 'created-by': 'kubeless', function: 'myFunction2' },
+            annotations: {},
           },
           spec: func2Spec,
         })
@@ -1017,6 +1020,7 @@ describe('KubelessDeploy', () => {
             name: 'myFunction3',
             namespace: 'default',
             labels: { 'created-by': 'kubeless', function: 'myFunction3' },
+            annotations: {},
           },
           spec: func3Spec,
         })
@@ -1100,6 +1104,7 @@ describe('KubelessDeploy', () => {
             name: 'myFunction',
             namespace: 'default',
             labels: { 'created-by': 'kubeless', function: functionName },
+            annotations: {},
           },
           spec: defaultFuncSpec(),
         })
@@ -1134,6 +1139,7 @@ describe('KubelessDeploy', () => {
             name: 'myFunction',
             namespace: 'default',
             labels: { 'created-by': 'kubeless', function: functionName },
+            annotations: {},
           },
           spec: defaultFuncSpec(),
         })

--- a/test/kubelessDeployFunction.test.js
+++ b/test/kubelessDeployFunction.test.js
@@ -136,6 +136,7 @@ describe('KubelessDeployFunction', () => {
             name: functionName,
             namespace: 'default',
             labels: { 'created-by': 'kubeless', function: functionName },
+            annotations: {},
           },
           spec: defaultFuncSpec(),
         })

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -109,13 +109,12 @@ function createDeploymentNocks(endpoint, func, funcSpec, options) {
         'created-by': 'kubeless',
         function: func,
       }, opts.labels),
+      annotations: {},
     },
     spec: funcSpec,
   };
   if (opts.description) {
-    postBody.metadata.annotations = {
-      'kubeless.serverless.com/description': opts.description,
-    };
+    postBody.metadata.annotations['kubeless.serverless.com/description'] = opts.description;
   }
   if (opts.labels) {
     postBody.spec.service.selector = _.assign(postBody.spec.service.selector);
@@ -148,6 +147,7 @@ function createDeploymentNocks(endpoint, func, funcSpec, options) {
         metadata: {
           name: func,
           labels: { function: func },
+          annotations: {},
           creationTimestamp: moment().add('60', 's'),
         },
         spec: funcSpec,


### PR DESCRIPTION
This makes it possible to use things like `kube2iam` which require annotations on the pod.

Eg.

```
functions:
  myFn:
    handler: handler.myFn
    annotations:
      iam.amazonaws.com/role: role-arn
```
