### PR TITLE
feat: Adding CPU limits

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -149,6 +149,7 @@ class KubelessDeploy {
         hostname: this.serverless.service.provider.hostname,
         defaultDNSResolution: this.serverless.service.provider.defaultDNSResolution,
         ingress: this.serverless.service.provider.ingress,
+        cpu: this.serverless.service.provider.cpu,
         memorySize: this.serverless.service.provider.memorySize,
         force: this.options.force,
         verbose: this.options.verbose,

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -57,7 +57,8 @@ function getFunctionDescription(
     memory,
     timeout,
     port,
-    secrets
+    secrets,
+    cpu
 ) {
   const funcs = {
     apiVersion: 'kubeless.io/v1beta1',
@@ -96,7 +97,7 @@ function getFunctionDescription(
   if (desc) {
     funcs.metadata.annotations['kubeless.serverless.com/description'] = desc;
   }
-  if (image || env || memory || secrets) {
+  if (image || env || memory || secrets || cpu) {
     const container = {
       name: funcName,
     };
@@ -117,16 +118,22 @@ function getFunctionDescription(
         );
       }
     }
-    if (memory) {
-      // If no suffix is given we assume the unit will be `Mi`
-      const memoryWithSuffix = memory.toString().match(/\d+$/) ?
-                `${memory}Mi` :
-                memory;
-      container.resources = {
-        limits: { memory: memoryWithSuffix },
-        requests: { memory: memoryWithSuffix },
-      };
+    if (memory || cpu) {
+      container.resources = { limits: {}, requests: {}};
+      if (memory) {
+        // If no suffix is given we assume the unit will be `Mi`
+        const memoryWithSuffix = memory.toString().match(/\d+$/) ?
+                  `${memory}Mi` :
+                  memory;
+        container.resources.limits.memory = memoryWithSuffix;
+        container.resources.requests.memory = memoryWithSuffix;
+      }
+      if (cpu) {
+        container.resources.limits.cpu = cpu;
+        container.resources.requests.cpu = cpu;
+      }
     }
+
     funcs.spec.deployment = {
       spec: {
         template: {
@@ -393,7 +400,8 @@ function deployFunction(f, namespace, runtime, contentType, options) {
     f.memorySize || options.memorySize,
     f.timeout || options.timeout,
     f.port,
-    f.secrets
+    f.secrets,
+    f.cpu || options.cpu
   );
   return functionsApi.getItem(funcs.metadata.name).then((res) => {
     if (res.code === 404) {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -119,7 +119,7 @@ function getFunctionDescription(
       }
     }
     if (memory || cpu) {
-      container.resources = { limits: {}, requests: {}};
+      container.resources = { limits: {}, requests: {} };
       if (memory) {
         // If no suffix is given we assume the unit will be `Mi`
         const memoryWithSuffix = memory.toString().match(/\d+$/) ?

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -743,6 +743,124 @@ describe('KubelessDeploy', () => {
         kubelessDeploy.deployFunction()
       ).to.be.fulfilled;
     });
+    it('should deploy a function with a cpu limit', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+      serverlessWithEnvVars.service.functions[functionName].cpu = '500m';
+      kubelessDeploy = instantiateKubelessDeploy(
+        pkgFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, defaultFuncSpec({
+        deployment: {
+          spec: {
+            template: {
+              spec: {
+                containers: [{
+                  name: functionName,
+                  resources: {
+                    limits: { cpu: '500m' },
+                    requests: { cpu: '500m' },
+                  },
+                }],
+              },
+            },
+          },
+        },
+      }));
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
+    it('should deploy a function with a cpu limit (in the provider definition)', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+      serverlessWithEnvVars.service.provider.cpu = '500m';
+      kubelessDeploy = instantiateKubelessDeploy(
+        pkgFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, defaultFuncSpec({
+        deployment: {
+          spec: {
+            template: {
+              spec: {
+                containers: [{
+                  name: functionName,
+                  resources: {
+                    limits: { cpu: '500m' },
+                    requests: { cpu: '500m' },
+                  },
+                }],
+              },
+            },
+          },
+        },
+      }));
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
+    it('should deploy a function with a memory and cpu limit', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+      serverlessWithEnvVars.service.functions[functionName].memorySize = '128Gi';
+      serverlessWithEnvVars.service.functions[functionName].cpu = '500m';
+      kubelessDeploy = instantiateKubelessDeploy(
+        pkgFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, defaultFuncSpec({
+        deployment: {
+          spec: {
+            template: {
+              spec: {
+                containers: [{
+                  name: functionName,
+                  resources: {
+                    limits: { cpu: '500m', memory: '128Gi' },
+                    requests: { cpu: '500m', memory: '128Gi' },
+                  },
+                }],
+              },
+            },
+          },
+        },
+      }));
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
+    it('should deploy a function with a memory and cpu limit (in the provider definition)', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+      serverlessWithEnvVars.service.provider.cpu = '500m';
+      serverlessWithEnvVars.service.provider.memorySize = '128Gi';
+      kubelessDeploy = instantiateKubelessDeploy(
+        pkgFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, defaultFuncSpec({
+        deployment: {
+          spec: {
+            template: {
+              spec: {
+                containers: [{
+                  name: functionName,
+                  resources: {
+                    limits: { cpu: '500m', memory: '128Gi' },
+                    requests: { cpu: '500m', memory: '128Gi' },
+                  },
+                }],
+              },
+            },
+          },
+        },
+      }));
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
     it('should deploy a function in a specific path', () => {
       const serverlessWithCustomPath = _.cloneDeep(serverlessWithFunction);
       serverlessWithCustomPath.service.functions[functionName].events = [{


### PR DESCRIPTION
Hey @andresmgot

I put this together at the request of our DevOps engineer who suggested we have cpu limits defined for the serverless functions so they wouldn't be deprived of the necessary resources. I know the other serverless frameworks don't support this (e.g. https://serverless.com/framework/docs/providers/aws/guide/serverless.yml/) but since kubeless is ran on a kubernetes cluster with a finite amount of resources, IMO it makes sense to me that we have the ability to declare this, so the cluster can add more nodes if necessary and not deprive a serverless function of the resources it needs.