### PR TITLE
feat: Adding affinity & tolerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,4 @@ $ serverless remove
 Serverless: Removing function: hello...
 Serverless: Function hello successfully deleted
 ```
+

--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -152,6 +152,7 @@ class KubelessDeploy {
         cpu: this.serverless.service.provider.cpu,
         memorySize: this.serverless.service.provider.memorySize,
         affinity: this.serverless.service.provider.affinity,
+        tolerations: this.serverless.service.provider.tolerations,
         force: this.options.force,
         verbose: this.options.verbose,
         log: this.serverless.cli.log.bind(this.serverless.cli),

--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -151,6 +151,7 @@ class KubelessDeploy {
         ingress: this.serverless.service.provider.ingress,
         cpu: this.serverless.service.provider.cpu,
         memorySize: this.serverless.service.provider.memorySize,
+        affinity: this.serverless.service.provider.affinity,
         force: this.options.force,
         verbose: this.options.verbose,
         log: this.serverless.cli.log.bind(this.serverless.cli),

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -61,7 +61,8 @@ function getFunctionDescription(
     timeout,
     port,
     secrets,
-    cpu
+    cpu,
+    affinity
 ) {
   const funcs = {
     apiVersion: 'kubeless.io/v1beta1',
@@ -100,7 +101,7 @@ function getFunctionDescription(
   if (desc) {
     funcs.metadata.annotations['kubeless.serverless.com/description'] = desc;
   }
-  if (image || env || memory || secrets || cpu) {
+  if (image || env || memory || secrets || cpu || affinity) {
     const container = {
       name: funcName,
     };
@@ -158,6 +159,10 @@ function getFunctionDescription(
         funcs.spec.deployment.spec.template.spec.volumes
           .push({ name: `${secret}-vol`, secret: { secretName: secret } });
       });
+    }
+
+    if (affinity) {
+      funcs.spec.deployment.spec.affinity = affinity;
     }
   }
   return funcs;
@@ -418,7 +423,8 @@ function deployFunction(f, namespace, runtime, contentType, options) {
     f.timeout || options.timeout,
     f.port,
     f.secrets,
-    f.cpu || options.cpu
+    f.cpu || options.cpu,
+    f.affinity || options.affinity
   );
   return functionsApi.getItem(funcs.metadata.name).then((res) => {
     if (res.code === 404) {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -62,7 +62,8 @@ function getFunctionDescription(
     port,
     secrets,
     cpu,
-    affinity
+    affinity,
+    tolerations
 ) {
   const funcs = {
     apiVersion: 'kubeless.io/v1beta1',
@@ -101,7 +102,7 @@ function getFunctionDescription(
   if (desc) {
     funcs.metadata.annotations['kubeless.serverless.com/description'] = desc;
   }
-  if (image || env || memory || secrets || cpu || affinity) {
+  if (image || env || memory || secrets || cpu || affinity || tolerations) {
     const container = {
       name: funcName,
     };
@@ -163,6 +164,9 @@ function getFunctionDescription(
 
     if (affinity) {
       funcs.spec.deployment.spec.affinity = affinity;
+    }
+    if (tolerations) {
+      funcs.spec.deployment.spec.tolerations = tolerations;
     }
   }
   return funcs;
@@ -424,7 +428,8 @@ function deployFunction(f, namespace, runtime, contentType, options) {
     f.port,
     f.secrets,
     f.cpu || options.cpu,
-    f.affinity || options.affinity
+    f.affinity || options.affinity,
+    f.tolerations || options.tolerations
   );
   return functionsApi.getItem(funcs.metadata.name).then((res) => {
     if (res.code === 404) {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -877,7 +877,91 @@ describe('KubelessDeploy', () => {
         kubelessDeploy.deployFunction()
       ).to.be.fulfilled;
     });
-    it('should deploy a function with a memory and cpu limit (in the provider definition)', () => {
+    it('should deploy a function with an affinity defined', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+
+      const affinityDefintion = {
+        nodeAffinity: {
+          requiredDuringSchedulingIgnoredDuringExecution: {
+            nodeSelectorTerms: [{
+              matchExpressions: [{
+                key: 'kubernetes.io/e2e-az-name',
+                operator: 'In',
+                values: ['e2e-az1', 'e2e-az2'],
+              }],
+            }],
+          },
+        },
+      };
+
+      serverlessWithEnvVars.service.functions[functionName].affinity = affinityDefintion;
+      kubelessDeploy = instantiateKubelessDeploy(
+        pkgFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, defaultFuncSpec({
+        deployment: {
+          spec: {
+            template: {
+              spec: {
+                containers: [{
+                  name: functionName,
+                }],
+              },
+            },
+            affinity: affinityDefintion,
+          },
+        },
+      }));
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
+
+    it('should deploy a function with an affinity defined (in the provider definition)', () => {
+      const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
+
+      const affinityDefintion = {
+        nodeAffinity: {
+          requiredDuringSchedulingIgnoredDuringExecution: {
+            nodeSelectorTerms: [{
+              matchExpressions: [{
+                key: 'kubernetes.io/e2e-az-name',
+                operator: 'In',
+                values: ['e2e-az1', 'e2e-az2'],
+              }],
+            }],
+          },
+        },
+      };
+
+      serverlessWithEnvVars.service.provider.affinity = affinityDefintion;
+      kubelessDeploy = instantiateKubelessDeploy(
+        pkgFile,
+        depsFile,
+        serverlessWithEnvVars
+      );
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, defaultFuncSpec({
+        deployment: {
+          spec: {
+            template: {
+              spec: {
+                containers: [{
+                  name: functionName,
+                }],
+              },
+            },
+            affinity: affinityDefintion,
+          },
+        },
+      }));
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
+
+    it('should deploy a function with an affinity defined (in the provider definition)', () => {
       const serverlessWithEnvVars = _.cloneDeep(serverlessWithFunction);
       serverlessWithEnvVars.service.provider.cpu = '500m';
       serverlessWithEnvVars.service.provider.memorySize = '128Gi';


### PR DESCRIPTION
We leverage some of the more granular controls of k8s, as such I'm expanding the surface area of the serverless kubeless APIs. I hope this is okay.

For more info on these pieces of functionality.
https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
https://kubernetes.io/docs/concepts/configuration/assign-pod-node/

**/cc @andresmgot**