### PR TITLE
Added support for configuring tls for ingress and additional ingress annotations.

### DIFF
--- a/examples/cert-manager-https/README.md
+++ b/examples/cert-manager-https/README.md
@@ -1,0 +1,15 @@
+# Cert manager https example
+
+In this example we will deploy a function that will have ssl automatically setup by cert manager.
+
+## Prerequisites 
+
+* Cert Manager install with [cluster issuer shim](https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html) setup.
+* Optional [external dns](https://github.com/kubernetes-incubator/external-dns) setup to automate dns configuration.
+
+## Deploy
+
+```console
+$ npm install
+$ serverless deploy
+```

--- a/examples/cert-manager-https/handler.py
+++ b/examples/cert-manager-https/handler.py
@@ -1,0 +1,2 @@
+def hello(event, context):
+    print event['data']

--- a/examples/cert-manager-https/package.json
+++ b/examples/cert-manager-https/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "hello-events",
+    "version": "1.0.0",
+    "description": "Example function for serverless kubeless",
+    "dependencies": {
+      "serverless-kubeless": "^0.4.0"
+    },
+    "devDependencies": {},
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "",
+    "license": "Apache-2.0"
+}
+  

--- a/examples/cert-manager-https/serverless.yml
+++ b/examples/cert-manager-https/serverless.yml
@@ -1,0 +1,25 @@
+service:
+  name: cert-manager-https
+
+plugins:
+  - serverless-kubeless
+
+provider:
+  name: kubeless
+  hostname: example.com
+  runtime: nodejs8
+  ingress:
+    additionalAnnotations:
+      kubernetes.io/tls-acme: "true"
+    tlsConfig:
+      - hosts:
+          - "example.com"
+        secretName: ingress-example-com-certs
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          method: get
+          path: hello

--- a/lib/ingress.js
+++ b/lib/ingress.js
@@ -32,7 +32,7 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
     ingress: _.defaults({
       class: 'nginx',
       additionalAnnotations: {},
-      tlsConfig: null,
+      tlsConfig: undefined,
     }),
   });
   const config = helpers.loadKubeConfig();

--- a/lib/ingress.js
+++ b/lib/ingress.js
@@ -31,6 +31,8 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
     defaultDNSResolution: 'nip.io',
     ingress: _.defaults({
       class: 'nginx',
+      additionalAnnotations: {},
+      tlsConfig: null,
     }),
   });
   const config = helpers.loadKubeConfig();
@@ -80,9 +82,10 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
           annotations: {
             'kubernetes.io/ingress.class': opts.ingress.class,
             [`${opts.ingress.class}.ingress.kubernetes.io/rewrite-target`]: '/',
+            ...opts.ingress.additionalAnnotations,
           },
         },
-        spec: { rules },
+        spec: { rules, tls: opts.ingress.tlsConfig },
       };
       extensions.ns.ingress.get(ruleName, (err) => {
         if (err === null) {

--- a/lib/ingress.js
+++ b/lib/ingress.js
@@ -79,11 +79,10 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
         kind: 'Ingress',
         metadata: {
           name: ruleName,
-          annotations: {
+          annotations: _.merge({
             'kubernetes.io/ingress.class': opts.ingress.class,
             [`${opts.ingress.class}.ingress.kubernetes.io/rewrite-target`]: '/',
-            ...opts.ingress.additionalAnnotations,
-          },
+          }, opts.ingress.additionalAnnotations),
         },
         spec: { rules, tls: opts.ingress.tlsConfig },
       };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Very simple changes just adding in code to handle a few additional ingress config options.

- ingress.additionalAnnotations: just extra annotations that get appended to the ingress annotations.
- ingress.tlsConfig: optional tls config for ingress.
