### PR TITLE
Namespace not used when getting services and pods

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -198,7 +198,7 @@ function waitForDeployment(funcName, requestMoment, namespace, options) {
         reject(`Unable to retrieve the status of the ${funcName} deployment`);
       }
       let runningPods = 0;
-      core.pods.get((err, podsInfo) => {
+      core.ns.pods.get((err, podsInfo) => {
         if (err) {
           if (err.message.match(/request timed out/)) {
             opts.log('Request timed out. Retrying...');

--- a/lib/get-info.js
+++ b/lib/get-info.js
@@ -94,7 +94,7 @@ function info(functions, service, options) {
       const core = new Api.Core(connectionOptions);
       const functionsApi = new CRD('apis/kubeless.io', 'v1beta1', namespace, 'functions');
       const extensions = new Api.Extensions(connectionOptions);
-      core.services.get((err, servicesInfo) => {
+      core.ns.services.get((err, servicesInfo) => {
         if (err) reject(new Error(err));
         functionsApi.getItem(f).catch((ferr) => reject(ferr)).then(fDesc => {
           extensions.ns.ingress(service).get((ierr, fIngress) => {

--- a/lib/invoke.js
+++ b/lib/invoke.js
@@ -112,7 +112,7 @@ function invoke(func, data, funcsDesc, options) {
         resolve(response);
       }
     };
-    core.services.get((err, servicesInfo) => {
+    core.ns.services.get((err, servicesInfo) => {
       if (err) {
         reject(err);
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.5.2",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.4.4",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -346,7 +346,7 @@ describe('KubelessDeploy', () => {
       const funcSpec = defaultFuncSpec();
       // First call, still deploying:
       nock(config.clusters[0].cluster.server)
-        .get('/api/v1/pods')
+        .get('/api/v1/namespaces/default/pods')
         .reply(200, {
           items: [{
             metadata: {
@@ -372,7 +372,7 @@ describe('KubelessDeploy', () => {
       const funcSpec = defaultFuncSpec();
       // First call, still deploying:
       nock(config.clusters[0].cluster.server)
-        .get('/api/v1/pods')
+        .get('/api/v1/namespaces/default/pods')
         .reply(200, {
           items: [{
             metadata: {
@@ -395,7 +395,7 @@ describe('KubelessDeploy', () => {
     it('should throw an error if the pod failed to start', () => {
       const funcSpec = defaultFuncSpec();
       nock(config.clusters[0].cluster.server)
-        .get('/api/v1/pods')
+        .get('/api/v1/namespaces/default/pods')
         .times(10)
         .reply(200, {
           items: [{
@@ -424,7 +424,7 @@ describe('KubelessDeploy', () => {
       const funcSpec = defaultFuncSpec();
       // First call, fails to retrieve status
       nock(config.clusters[0].cluster.server)
-        .get('/api/v1/pods')
+        .get('/api/v1/namespaces/default/pods')
         .replyWithError('etcdserver: request timed out');
       // Second call, ready:
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, funcSpec);
@@ -439,7 +439,7 @@ describe('KubelessDeploy', () => {
       // First call, fails to retrieve status
       nock(config.clusters[0].cluster.server)
         .persist()
-        .get('/api/v1/pods')
+        .get('/api/v1/namespaces/default/pods')
         .reply(200, { items: [] });
       // Second call, ready:
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, funcSpec);
@@ -1311,7 +1311,7 @@ describe('KubelessDeploy', () => {
       };
       nock(config.clusters[0].cluster.server)
         .persist()
-        .get('/api/v1/pods')
+        .get('/api/v1/namespaces/default/pods')
         .reply(200, () => ({
           items: [
             {

--- a/test/kubelessInfo.test.js
+++ b/test/kubelessInfo.test.js
@@ -86,7 +86,6 @@ describe('KubelessInfo', () => {
   function mockGetCalls(config, functions, functionModif) {
     const namespaces = _.map(functions, f => f.namespace);
     _.each(namespaces, ns => {
-      console.log(`Setup /api/v1/namespaces/${ns}/services`);
       nock(config.clusters[0].cluster.server)
         .get(`/api/v1/namespaces/${ns}/services`)
         .reply(200, {

--- a/test/kubelessInfo.test.js
+++ b/test/kubelessInfo.test.js
@@ -196,8 +196,8 @@ describe('KubelessInfo', () => {
     });
     it('should return logs with the correct formating', () => {
       mockGetCalls(config, [
-        { id: func, namespace: 'default' }, 
-        { id: 'my-function-1', namespace: 'custom-1' }
+        { id: func, namespace: 'default' },
+        { id: 'my-function-1', namespace: 'custom-1' },
       ]);
       const kubelessInfo = new KubelessInfo(serverless, { function: func });
       return expect(kubelessInfo.infoFunction({ color: false })).to.become(

--- a/test/kubelessInvoke.test.js
+++ b/test/kubelessInvoke.test.js
@@ -35,7 +35,7 @@ require('chai').use(chaiAsPromised);
 
 function nocksvc(url, funcs) {
   nock(url)
-    .get('/api/v1/services')
+    .get('/api/v1/namespaces/default/services')
     .reply(200, {
       items: _.map(_.flatten([funcs]), f => ({
         metadata:

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -141,7 +141,7 @@ function createDeploymentNocks(endpoint, func, funcSpec, options) {
     .reply(200, opts.postReply);
   nock(endpoint)
     .persist()
-    .get('/api/v1/pods')
+    .get(`/api/v1/namespaces/${opts.namespace}/pods`)
     .reply(200, JSON.stringify({
       items: [{
         metadata: {


### PR DESCRIPTION
Fixes: #160

**Background**

The way our k8s access control is configured, users generally don't have permissions to list all pods or services in the cluster.

For example `GET /api/v1/pods` will fail with
`User "<user>" cannot list resource "pods" in API group "" at the cluster scope`

**Issue**

Deploying using `serverless deploy` itself works, but the deployment progress checks fail, as these use `/api/v1/pods` and `/api/v1/services`.

The deployment code is namespace-aware, so I think the progress checks should use the namespaced APIs, too, i.e. `/api/v1/namespaces/<namespace>/pods`.