### PR TITLE
Fix for affinity not being added to deployment spec

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -168,7 +168,7 @@ function getFunctionDescription(
     }
 
     if (affinity) {
-      funcs.spec.deployment.spec.affinity = affinity;
+      funcs.spec.deployment.spec.template.spec.affinity = affinity;
     }
     if (tolerations) {
       funcs.spec.deployment.spec.tolerations = tolerations;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -978,12 +978,12 @@ describe('KubelessDeploy', () => {
               spec: {
                 containers: [{
                   name: functionName,
-                  }],
-                  affinity: affinityDefintion,
-                },
+                }],
+                affinity: affinityDefintion,
               },
             },
           },
+        },
       }));
       return expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()
@@ -1020,12 +1020,12 @@ describe('KubelessDeploy', () => {
               spec: {
                 containers: [{
                   name: functionName,
-                  }],
-                  affinity: affinityDefintion,
-                },
+                }],
+                affinity: affinityDefintion,
               },
             },
           },
+        },
       }));
       return expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -978,12 +978,12 @@ describe('KubelessDeploy', () => {
               spec: {
                 containers: [{
                   name: functionName,
-                }],
+                  }],
+                  affinity: affinityDefintion,
+                },
               },
             },
-            affinity: affinityDefintion,
           },
-        },
       }));
       return expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()
@@ -1020,12 +1020,12 @@ describe('KubelessDeploy', () => {
               spec: {
                 containers: [{
                   name: functionName,
-                }],
+                  }],
+                  affinity: affinityDefintion,
+                },
               },
             },
-            affinity: affinityDefintion,
           },
-        },
       }));
       return expect( // eslint-disable-line no-unused-expressions
         kubelessDeploy.deployFunction()


### PR DESCRIPTION
Set affinity in the deployment spec instead of in the pod itself.