### PR TITLE
Bumped package version to fix broken examples

### DIFF
--- a/examples/cert-manager-https/package.json
+++ b/examples/cert-manager-https/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Example function for serverless kubeless",
     "dependencies": {
-      "serverless-kubeless": "^0.4.0"
+      "serverless-kubeless": "^0.7.0"
     },
     "devDependencies": {},
     "scripts": {

--- a/examples/event-trigger-python/package.json
+++ b/examples/event-trigger-python/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/examples/get-python/package.json
+++ b/examples/get-python/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/examples/get-ruby/package.json
+++ b/examples/get-ruby/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/examples/http-custom-path/package.json
+++ b/examples/http-custom-path/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/examples/multi-python/package.json
+++ b/examples/multi-python/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/examples/node-chaining-functions/package.json
+++ b/examples/node-chaining-functions/package.json
@@ -6,7 +6,7 @@
     "lodash": "^4.1.0"
   },
   "devDependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/examples/post-go/package.json
+++ b/examples/post-go/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/examples/post-nodejs/package.json
+++ b/examples/post-nodejs/package.json
@@ -6,7 +6,7 @@
     "lodash": "^4.1.0"
   },
   "devDependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/examples/post-php/package.json
+++ b/examples/post-php/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/examples/post-python/package.json
+++ b/examples/post-python/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/examples/post-ruby/package.json
+++ b/examples/post-ruby/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Example function for serverless kubeless",
   "dependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/examples/scheduled-node/package.json
+++ b/examples/scheduled-node/package.json
@@ -6,7 +6,7 @@
     "lodash": "^4.1.0"
   },
   "devDependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/examples/todo-app/backend/package.json
+++ b/examples/todo-app/backend/package.json
@@ -13,6 +13,6 @@
     "uuid": "^2.0.3"
   },
   "devDependencies": {
-    "serverless-kubeless": "^0.4.0"
+    "serverless-kubeless": "^0.7.0"
   }
 }


### PR DESCRIPTION
Found that `cert-manager-https` example was not working due to reference to `^0.4.0` when support for `tlsConfig` and `additionalAnnotations` was not added until `0.6.1`. 

All examples had the same version, so I bumped it to the latest.

Fixes #166.
