### PR TITLE
defines optional servicePort

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -76,6 +76,7 @@ function getFunctionDescription(
     memory,
     timeout,
     port,
+    servicePort,
     secrets,
     cpu,
     affinity,
@@ -104,7 +105,7 @@ function getFunctionDescription(
       service: {
         ports: [{
           name: 'http-function-port',
-          port: Number(port || 8080),
+          port: Number(servicePort || port || 8080),
           protocol: 'TCP',
           targetPort: Number(port || 8080),
         }],
@@ -436,6 +437,7 @@ function deployFunction(f, namespace, runtime, contentType, options) {
     f.memorySize || options.memorySize,
     f.timeout || options.timeout,
     f.port,
+    f.servicePort,
     f.secrets,
     f.cpu || options.cpu,
     f.affinity || options.affinity,


### PR DESCRIPTION
It is followon pull request for https://github.com/kubeless/kubeless/pull/993

After updating runtime images to use non-root user it is become impossible to run functions on port 80. To fix this Service can map port 80 to target port 8080. To support this this pull request was prepared. It allows define `servicePort` to distinguish between container and service ports
