### PR TITLE
Adds support for separate ingress class and ingress names.

### DIFF
--- a/examples/custom-ingress/README.md
+++ b/examples/custom-ingress/README.md
@@ -1,0 +1,72 @@
+# Simple Hello World function with custom kubernetes Ingress class & annotations
+
+In this example we will deploy a function that with custom annotations in its ingress metadata. Check the `serverless.yml` file to see the specific syntax.
+
+## Pre requisites
+
+We will need to have an Ingress controller deployed.
+
+## Background info
+
+An Ingress controller will typically have a class name, for example:
+
+```
+kubernetes.io/ingress.class: nginx
+# or perhaps
+kubernetes.io/ingress.class: azure/application-gateway
+```
+
+An Ingress controller will also have annotations to control their behavior, like these:
+
+```
+nginx.ingress.kubernetes.io/example-rule-1: true
+# or another ingress annotation might look like this
+appgw.ingress.kubernetes.io/rule-example-2: false
+```
+
+An Ingress class isn't nessesarily the same as it's name in annotations. 
+(seen above with `azure/application-gateway` and `appgw`)
+
+## Deployment
+
+```console
+$ npm install
+$ serverless deploy
+Serverless: Packaging service...
+Serverless: Excluding development dependencies...
+Serverless: Function hello successfully deployed
+```
+
+Make sure you have `kubectl` installed and that it can access your cluster (See documentation for your cloud provider if using a managed k8s service.)
+
+We can now get the Ingress information for our new function. (If this doesn't work, as a workout use `edit` instead of `describe`)
+
+```
+$ kubectl describe Ingress hello
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    ingressName.ingress.kubernetes.io/rewrite-target: /
+    ingressName.ingress.kubernetes.io/example-rule-1: "true"
+    ingressName.ingress.kubernetes.io/example-rule-2: "false"
+    kubernetes.io/ingress.class: foo/bar-ingress-class
+  creationTimestamp: "2019-08-07T11:09:20Z"
+  generation: 2
+  name: hello
+  namespace: default
+  resourceVersion: "191340"
+  selfLink: /apis/extensions/v1beta1/namespaces/default/ingresses/hello
+  uid: aaaaa000-a000-a000-a000-a000a000a000
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - backend:
+          serviceName: hello
+          servicePort: 8080
+        path: /hello/
+status:
+  loadBalancer: {}
+```

--- a/examples/custom-ingress/handler.py
+++ b/examples/custom-ingress/handler.py
@@ -1,0 +1,2 @@
+def hello(event, context):
+    return "hello world"

--- a/examples/custom-ingress/package.json
+++ b/examples/custom-ingress/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "hello",
+  "version": "1.0.0",
+  "description": "Example function for serverless kubeless",
+  "dependencies": {
+    "serverless-kubeless": "^0.7.2"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache-2.0"
+}

--- a/examples/custom-ingress/serverless.yml
+++ b/examples/custom-ingress/serverless.yml
@@ -1,0 +1,23 @@
+service: hello
+
+provider:
+  name: kubeless
+  runtime: python2.7
+  defaultDNSResolution: 'xip.io'
+  ingress:
+    class: "foo/bar-ingress" # Becomes: `kubernetes.io/ingress.class: foo/bar-ingress`
+    name: "ingressName"      # Becomes: `ingressName.ingress.kubernetes.io/rewrite-target: /`
+    additionalAnnotations: 
+      "ingressName.ingress.kubernetes.io/example-rule-1": true
+      "ingressName.ingress.kubernetes.io/example-rule-2": false
+    
+
+plugins:
+  - serverless-kubeless
+
+functions:
+  hello:
+    handler: handler.hello
+    events:
+      - http:
+          path: /hello

--- a/lib/ingress.js
+++ b/lib/ingress.js
@@ -33,6 +33,7 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
       class: 'nginx',
       additionalAnnotations: {},
       tlsConfig: undefined,
+      name: undefined,
     }),
   });
   const config = helpers.loadKubeConfig();
@@ -81,7 +82,9 @@ function addIngressRuleIfNecessary(ruleName, functions, options) {
           name: ruleName,
           annotations: _.merge({
             'kubernetes.io/ingress.class': opts.ingress.class,
-            [`${opts.ingress.class}.ingress.kubernetes.io/rewrite-target`]: '/',
+            [`${
+              opts.ingress.name || opts.ingress.class
+            }.ingress.kubernetes.io/rewrite-target`]: '/',
           }, opts.ingress.additionalAnnotations),
         },
         spec: { rules, tls: opts.ingress.tlsConfig },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This PR lets users optionally specify an ingress name alongside the class, with the following syntax:
```
provider:
  name: kubeless
  ingress: 
    class: "azure/application-gateway"
    name: "appgw" # <- New!
```

This is necessary to support Azure's `Application Gateway Ingress Controller (AGIC)`, as its class `azure/application-gateway` contains a `/`, which is an illegal character in annotation names.

[See here for an example of the AGIC class](https://azure.github.io/application-gateway-kubernetes-ingress/tutorial/#ExposeServicesOverHTTP) 

[And here for an example of the (different) name AGIC has in annotations](https://azure.github.io/application-gateway-kubernetes-ingress/annotations/)

