### PR TITLE
Allow function level runtime override

### DIFF
--- a/deploy/kubelessDeploy.js
+++ b/deploy/kubelessDeploy.js
@@ -101,7 +101,8 @@ class KubelessDeploy {
           });
           s.on('end', () => {
             if (description.handler) {
-              const depFile = helpers.getRuntimeDepfile(runtime, kubelessConfig);
+              const depFile = helpers.getRuntimeDepfile(description.runtime || runtime,
+                 kubelessConfig);
               this.getFileContent(pkg, depFile)
                 .catch(() => {
                   // No requirements found

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -423,7 +423,7 @@ function deployFunction(f, namespace, runtime, contentType, options) {
   const funcs = getFunctionDescription(
     f.id,
     namespace,
-    runtime,
+    f.runtime || runtime,
     f.image,
     f.deps,
     f.content,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -190,11 +190,43 @@ describe('KubelessDeploy', () => {
         kubelessDeploy.deployFunction()
       ).to.be.fulfilled;
     });
+    it('should deploy a function (nodejs) with function level runtime override', () => {
+      depsFile = path.join(cwd, 'package.json');
+      fs.writeFileSync(depsFile, 'nodejs function deps');
+      serverlessWithFunction.service.functions[functionName].runtime = 'nodejs6';
+      kubelessDeploy = instantiateKubelessDeploy(pkgFile, depsFile, _.defaultsDeep(
+        { service: { provider: { runtime: 'ruby2.4' } } },
+        serverlessWithFunction
+      ));
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, defaultFuncSpec({
+        deps: 'nodejs function deps',
+        runtime: 'nodejs6',
+      }));
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
     it('should deploy a function (ruby)', () => {
       depsFile = path.join(cwd, 'Gemfile');
       fs.writeFileSync(depsFile, 'ruby function deps');
       kubelessDeploy = instantiateKubelessDeploy(pkgFile, depsFile, _.defaultsDeep(
         { service: { provider: { runtime: 'ruby2.4' } } },
+        serverlessWithFunction
+      ));
+      mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, defaultFuncSpec({
+        deps: 'ruby function deps',
+        runtime: 'ruby2.4',
+      }));
+      return expect( // eslint-disable-line no-unused-expressions
+        kubelessDeploy.deployFunction()
+      ).to.be.fulfilled;
+    });
+    it('should deploy a function (ruby) with function level runtime override', () => {
+      depsFile = path.join(cwd, 'Gemfile');
+      fs.writeFileSync(depsFile, 'ruby function deps');
+      serverlessWithFunction.service.functions[functionName].runtime = 'ruby2.4';
+      kubelessDeploy = instantiateKubelessDeploy(pkgFile, depsFile, _.defaultsDeep(
+        { service: { provider: { runtime: 'golang1.11' } } },
         serverlessWithFunction
       ));
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, defaultFuncSpec({


### PR DESCRIPTION
Added support function level `runtime` override :

```yaml
service: my-service
provider: 
  name: kubeless
  runtime: nodejs8
functions:
  myFunction1:
    handler: nodejs10handler.handle
    runtime: nodejs10
  myFunction2:
    handler: nodejs8handler.handle
```

Analog of the function `runtime` override in the AWS provider:
https://serverless.com/framework/docs/providers/aws/guide/functions#configuration
