### PR TITLE
Add support for "dynamic" EKS token auth

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -21,6 +21,7 @@ const fs = require('fs');
 const moment = require('moment');
 const path = require('path');
 const yaml = require('js-yaml');
+const proc = require('child_process');
 
 function loadKubeConfig() {
   const kubeCfgPath = path.join(process.env.HOME, '.kube/config');
@@ -104,6 +105,7 @@ function getToken(userInfo) {
   const token = _.get(userInfo, 'user.token') ||
     _.get(userInfo, 'user.auth-provider.config.id-token');
   const accessToken = _.get(userInfo, 'user.auth-provider.config.access-token');
+  let cmd = _.get(userInfo, 'user.exec.command');
   if (token) {
     return token;
   } else if (accessToken) {
@@ -117,6 +119,23 @@ function getToken(userInfo) {
       }
     }
     return accessToken;
+  } else if (cmd && cmd == 'aws') {
+    const args = _.get(userInfo, 'user.exec.args');
+    if (args) {
+      cmd = cmd + ' ' + args.join(' ');
+    }
+    const profile = _.find(userInfo.user.exec.env, e => e.name === 'AWS_PROFILE' );
+    if (profile) {
+      cmd = cmd + ' --profile ' + profile.value;
+    }
+    let output = {}
+    try {
+      output = proc.execSync(cmd);
+    } catch (err) {
+      throw new Error('Failed to refresh token: ' + err.message);
+    }
+    const resultObj = JSON.parse(output);
+    return resultObj['status']['token'];
   }
   return null;
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -124,9 +124,12 @@ function getToken(userInfo) {
     if (args) {
       cmd = `${cmd} ${args.join(' ')}`;
     }
-    const profile = _.find(userInfo.user.exec.env, e => e.name === 'AWS_PROFILE');
-    if (profile) {
-      cmd = `${cmd} --profile ${profile.value}`;
+    const env = _.get(userInfo, 'user.exec.env', []);
+    if (env) {
+      const profile = _.find(env, e => e.name === 'AWS_PROFILE');
+      if (profile) {
+        cmd = `${cmd} --profile ${profile.value}`;
+      }
     }
     let output = {};
     try {
@@ -135,7 +138,10 @@ function getToken(userInfo) {
       throw new Error(`Failed to refresh token: ${err.message}`);
     }
     const resultObj = JSON.parse(output);
-    return resultObj.status.token;
+    const execToken = _.get(resultObj, 'status.token');
+    if (execToken) {
+      return execToken;
+    }
   }
   return null;
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -119,23 +119,23 @@ function getToken(userInfo) {
       }
     }
     return accessToken;
-  } else if (cmd && cmd == 'aws') {
+  } else if (cmd && cmd === 'aws') {
     const args = _.get(userInfo, 'user.exec.args');
     if (args) {
-      cmd = cmd + ' ' + args.join(' ');
+      cmd = `${cmd} ${args.join(' ')}`;
     }
-    const profile = _.find(userInfo.user.exec.env, e => e.name === 'AWS_PROFILE' );
+    const profile = _.find(userInfo.user.exec.env, e => e.name === 'AWS_PROFILE');
     if (profile) {
-      cmd = cmd + ' --profile ' + profile.value;
+      cmd = `${cmd} --profile ${profile.value}`;
     }
-    let output = {}
+    let output = {};
     try {
       output = proc.execSync(cmd);
     } catch (err) {
-      throw new Error('Failed to refresh token: ' + err.message);
+      throw new Error(`Failed to refresh token: ${err.message}`);
     }
     const resultObj = JSON.parse(output);
-    return resultObj['status']['token'];
+    return resultObj.status.token;
   }
   return null;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
AWS EKS utilizes the kubeconfig support for [client-go credential plugins](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins) to execute the `aws` CLI command to receive user credentials when authenticating to an EKS cluster. This PR adds support to serverless-kubeless to use such configs as another access token mechanism and should address issue #140 


(Thanks to the [Javascript Kubernetes Client cloud_auth](https://github.com/kubernetes-client/javascript/blob/master/src/cloud_auth.ts) for the general idea of how to do this.)