### PR TITLE
Pass AWS_PROFILE value as an environment variable

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -130,7 +130,7 @@ function getToken(userInfo) {
     if (env) {
       const profile = _.find(env, e => e.name === 'AWS_PROFILE');
       if (profile) {
-        envvars['AWS_PROFILE'] = profile.value;
+        envvars.AWS_PROFILE = profile.value;
       }
     }
     let output = {};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -126,15 +126,16 @@ function getToken(userInfo) {
       cmd = `${cmd} ${args.join(' ')}`;
     }
     const env = _.get(userInfo, 'user.exec.env', []);
+    const envvars = process.env;
     if (env) {
       const profile = _.find(env, e => e.name === 'AWS_PROFILE');
       if (profile) {
-        cmd = `${cmd} --profile ${profile.value}`;
+        envvars['AWS_PROFILE'] = profile.value;
       }
     }
     let output = {};
     try {
-      output = proc.execSync(cmd);
+      output = proc.execSync(cmd, envvars);
     } catch (err) {
       throw new Error(`Failed to refresh token: ${err.message}`);
     }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -126,7 +126,7 @@ function getToken(userInfo) {
       cmd = `${cmd} ${args.join(' ')}`;
     }
     const env = _.get(userInfo, 'user.exec.env', []);
-    const envvars = process.env;
+    const envvars = Object.assign({}, process.env);
     if (env) {
       const profile = _.find(env, e => e.name === 'AWS_PROFILE');
       if (profile) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Thanks to contributors, dynamic EKS credentials have been supported since the following PRs(https://github.com/serverless/serverless-kubeless/pull/189, https://github.com/serverless/serverless-kubeless/pull/192).

However, the above commits did not properly passed the `AWS_PROFILE` value: `aws-iam-authenticator` breaks because it does not know the `--profile` argument. Thus, I created another envvar map for child process, put `AWS_PROFILE` value inside the map, and passed the map to the child process.

Passing `AWS_PROFILE` as an environment variable will not break `aws`.