### PR TITLE
remove shell-escaping url in S3ZipContent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ services:
 - docker
 env:
   global:
-  - KUBELESS_VERSION: v1.0.0-alpha.8
-  - KUBELESS_KAFKA_VERSION: v1.0.0-beta.0
+  - KUBELESS_VERSION: v1.0.6
+  - KUBELESS_KAFKA_VERSION: v1.0.2
   - MINIKUBE_VERSION: v0.25.2
   - REPO_DOMAIN: serverless
   - REPO_NAME: serverless-kubeless

--- a/lib/strategy/s3_zip_content.js
+++ b/lib/strategy/s3_zip_content.js
@@ -21,7 +21,6 @@ const crypto = require('crypto');
 const fs = require('fs');
 const AWS = require('aws-sdk');
 const BbPromise = require('bluebird');
-const shellescape = require('shell-escape');
 
 class S3ZipContent {
   constructor(strategy, options) {
@@ -56,9 +55,8 @@ class S3ZipContent {
             Expires: options.expires,
           });
 
-          // fixme: unescaped url in pkg/utils/kubelessutil.go:82
           resolve({
-            content: shellescape([url]),
+            content: url,
             checksum: `sha256:${shasum.digest('hex')}`,
             contentType: 'url+zip',
           });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2018,11 +2018,6 @@
       "resolved": "https://artifactory.rnd-hub.com:443/artifactory/api/npm/ws-npm/semver/-/semver-5.6.0.tgz",
       "integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ=",
       "dev": true
-    },
-    "shell-escape": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
-      "integrity": "sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM="
     },
     "shelljs": {
       "version": "0.7.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "jszip": "^3.1.3",
     "kubernetes-client": "^3.12.0",
     "lodash": "^4.17.4",
-    "moment": "^2.18.1",
-    "shell-escape": "^0.2.0"
+    "moment": "^2.18.1"
   },
   "devDependencies": {
     "chai": "^4.0.2",


### PR DESCRIPTION
Hello,
when I deploy a Kubeless function with strategy: S3ZipContent, the deploy fails.

The pod goes in Init:CrashLoopBackOff status because the Kubeless prepare initContainer cannot retrieve the artifact from the bucket using the S3 presigned url.

Logs of the prepare initContainer:
```
sh: 1: -L: not found
```

The issue seems related to the CURL command in the preapre container that has the url argument with two quotes before and after the url. 

Example:

```
curl ''https://grid.photosi.com/kubeless-artifacts-test/microservice-sls-test-1583329211862.zip?AWSAccessKeyId=XXXXX&Expires=1614865212&Signature=a%2Fc%2F5A3k3G0EbL%2Fz0Up9u8m6pN0%3D''
          -L --silent --output /tmp/func.fromurl && echo 'f68e1c7f7427afdc65b4cdcd514239fdb3ffd4850cb00cd6032189305b9ee827  /tmp/func.fromurl'
          > /tmp/func.sha256 && sha256sum -c /tmp/func.sha256 && unzip -o /tmp/func.fromurl
          -d /kubeless && cp /src/project.csproj /kubeless

```

Seems that shellescape in lib/strategy/s3_zip_content.js is the cause of this issue and I think it should be no more necessary because of [this commit](https://github.com/kubeless/kubeless/commit/f3191b29946bd8a18fcd5ac124e8feb174b786fa) to the kubeless project.

I hope this PR could be merged to fix issues with S3ZipContent deploys.
Let me know if you have any questions, comments or suggestions.

Thank you very much for your work,
Lorenzo Angelini




