### PR TITLE
remove depFile check,  dependency file is not mandatory in Kubeless runtimes

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -219,11 +219,6 @@ function getRuntimeDepfile(runtime, configMap) {
       depFile = r.depName;
     }
   });
-  if (!depFile) {
-    throw new Error(
-      `The runtime ${runtime} is not supported yet`
-    );
-  }
   return depFile;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
fixes #202 .

No problems with null depFile (see [this](https://github.com/serverless/serverless-kubeless/blob/a31d1282213763ec4ada914324d254291699d9d9/deploy/kubelessDeploy.js#L123)).