### PR TITLE
waitForDeployment should also waits for service presence

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -257,10 +257,35 @@ function waitForDeployment(funcName, requestMoment, namespace, options) {
               // The pods may be running for a short time
               // so we should ensure that they are stable
               successfulCount++;
-              if (successfulCount === 2) {
+              if (successfulCount >= 2) {
                 opts.log(`Function ${funcName} successfully deployed`);
-                clearInterval(loop);
-                resolve();
+                // The pod is running successfully. Check if the function service is ready
+                core.ns.services.get((svcErr, svcsInfo) => {
+                  if (svcErr) {
+                    if (svcErr.message.match(/request timed out/)) {
+                      opts.log('Request timed out. Retrying...');
+                    } else {
+                      throw svcErr;
+                    }
+                  } else {
+                    // Get the svc for current function
+                    const functionSvcs = _.filter(
+                      svcsInfo.items,
+                      (svc) => (
+                        !_.isEmpty(svc.metadata.labels) &&
+                        svc.metadata.labels.function === funcName &&
+                        !svc.metadata.deletionTimestamp
+                      )
+                    );
+                    if (_.isEmpty(functionSvcs)) {
+                      retries++;
+                      opts.log(`Unable to find internal service for ${funcName}. Retrying...`);
+                    } else {
+                      clearInterval(loop);
+                      resolve();
+                    }
+                  }
+                });
               }
             } else if (opts.verbose) {
               successfulCount = 0;

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -212,7 +212,7 @@ function waitForDeployment(funcName, requestMoment, namespace, options) {
   let previousPodStatus = '';
   return new BbPromise((resolve, reject) => {
     const loop = setInterval(() => {
-      if (retries > 3) {
+      if (retries > 10) {
         opts.log(
           `Giving up, unable to retrieve the status of the ${funcName} deployment. `
         );

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -258,7 +258,6 @@ function waitForDeployment(funcName, requestMoment, namespace, options) {
               // so we should ensure that they are stable
               successfulCount++;
               if (successfulCount >= 2) {
-                opts.log(`Function ${funcName} successfully deployed`);
                 // The pod is running successfully. Check if the function service is ready
                 core.ns.services.get((svcErr, svcsInfo) => {
                   if (svcErr) {
@@ -281,6 +280,7 @@ function waitForDeployment(funcName, requestMoment, namespace, options) {
                       retries++;
                       opts.log(`Unable to find internal service for ${funcName}. Retrying...`);
                     } else {
+                      opts.log(`Function ${funcName} successfully deployed`);
                       clearInterval(loop);
                       resolve();
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -1448,6 +1448,28 @@ describe('KubelessDeploy', () => {
               },
             }],
         }));
+      nock(config.clusters[0].cluster.server)
+        .persist()
+        .get('/api/v1/namespaces/default/services')
+        .reply(200, () => ({
+          items: [
+            {
+              metadata: {
+                name: 'myFunction3',
+                labels: { function: 'myFunction3' },
+                annotations: {},
+                creationTimestamp: moment().add('60', 's'),
+              },
+            },
+            {
+              metadata: {
+                name: functionName,
+                labels: { function: functionName },
+                annotations: {},
+                creationTimestamp: moment().add('60', 's'),
+              },
+            }],
+        }));
 
       // Call for myFunction1
       mocks.createDeploymentNocks(config.clusters[0].cluster.server, functionName, funcSpec, {

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -138,6 +138,19 @@ function createDeploymentNocks(endpoint, func, funcSpec, options) {
         },
       }],
     }));
+  nock(endpoint)
+    .persist()
+    .get(`/api/v1/namespaces/${opts.namespace}/services`)
+    .reply(200, JSON.stringify({
+      items: [{
+        metadata: {
+          name: func,
+          labels: { function: func },
+          annotations: {},
+          creationTimestamp: moment().add('60', 's'),
+        },
+      }],
+    }));
 }
 
 function createTriggerNocks(endpoint, func, hostname, p, options) {


### PR DESCRIPTION
The "waitForDeployment" method in deploy.js module is waiting for running function pods before creating other resources (eg triggers).
It should also waits for the presence of the service used by the deployed function.
Without this pull request the creation of some resource could fail. Thus the creation of an HTTP Trigger sometimes fails because the function is deployed but the service isn't.