### PR TITLE
Add labels specified in serverless.yml functions to triggers

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -402,6 +402,7 @@ function deployMQTrigger(mqType, name, namespace, topic, options) {
       namespace,
       labels: {
         'created-by': 'kubeless',
+        ...options.labels
       },
     },
     spec: {
@@ -440,6 +441,7 @@ function deployScheduleTrigger(name, namespace, schedule, options) {
       namespace,
       labels: {
         'created-by': 'kubeless',
+        ...options.labels
       },
     },
     spec: {
@@ -476,6 +478,7 @@ function deployHttpTrigger(name, namespace, path, options) {
       namespace,
       labels: {
         'created-by': 'kubeless',
+        ...options.labels
       },
       annotations: Object.assign(baseAnnotations, options.ingress.additionalAnnotations),
     },
@@ -590,7 +593,7 @@ function handleMQTDeployment(trigger, name, namespace, options) {
     name,
     namespace,
     mqTrigger.topic,
-    { log: options.log }
+    options
   );
 }
 
@@ -614,6 +617,7 @@ function deployTrigger(event, funcName, namespace, service, options) {
           log: options.log,
           ingress: options.ingress || {},
           hostname: event.hostname || options.hostname || defaultHostname,
+          labels: options.labels
         }
       );
       break;
@@ -625,7 +629,10 @@ function deployTrigger(event, funcName, namespace, service, options) {
         event.trigger,
         funcName,
         namespace,
-        { log: options.log }
+        { 
+            log: options.log, 
+            labels: options.labels
+        }
       );
       break;
     case 'schedule':
@@ -636,7 +643,10 @@ function deployTrigger(event, funcName, namespace, service, options) {
         funcName,
         namespace,
         event.schedule,
-        { log: options.log }
+        {
+            log: options.log,
+            labels: options.labels
+        }
       );
       break;
     default:
@@ -661,6 +671,7 @@ function deploy(functions, runtime, service, options) {
         verbose: false,
         log: console.log,
         contentType: ('contentType' in description) ? description.contentType : 'text',
+        labels: description.labels || {}
       });
 
       const ns = description.namespace || opts.namespace;

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -400,10 +400,10 @@ function deployMQTrigger(mqType, name, namespace, topic, options) {
     metadata: {
       name: _.kebabCase(`${name}-${topic}`),
       namespace,
-      labels: {
-        'created-by': 'kubeless',
-        ...options.labels
-      },
+      labels: Object.assign(
+        { 'created-by': 'kubeless' },
+        options.labels
+      ),
     },
     spec: {
       functionSelector: {
@@ -439,10 +439,10 @@ function deployScheduleTrigger(name, namespace, schedule, options) {
     metadata: {
       name,
       namespace,
-      labels: {
-        'created-by': 'kubeless',
-        ...options.labels
-      },
+      labels: Object.assign(
+        { 'created-by': 'kubeless' },
+        options.labels
+      ),
     },
     spec: {
       'function-name': name,
@@ -476,10 +476,10 @@ function deployHttpTrigger(name, namespace, path, options) {
     metadata: {
       name,
       namespace,
-      labels: {
-        'created-by': 'kubeless',
-        ...options.labels
-      },
+      labels: Object.assign(
+        { 'created-by': 'kubeless' },
+        options.labels
+      ),
       annotations: Object.assign(baseAnnotations, options.ingress.additionalAnnotations),
     },
     spec: {
@@ -617,7 +617,7 @@ function deployTrigger(event, funcName, namespace, service, options) {
           log: options.log,
           ingress: options.ingress || {},
           hostname: event.hostname || options.hostname || defaultHostname,
-          labels: options.labels
+          labels: options.labels,
         }
       );
       break;
@@ -629,9 +629,9 @@ function deployTrigger(event, funcName, namespace, service, options) {
         event.trigger,
         funcName,
         namespace,
-        { 
-            log: options.log, 
-            labels: options.labels
+        {
+          log: options.log,
+          labels: options.labels,
         }
       );
       break;
@@ -644,8 +644,8 @@ function deployTrigger(event, funcName, namespace, service, options) {
         namespace,
         event.schedule,
         {
-            log: options.log,
-            labels: options.labels
+          log: options.log,
+          labels: options.labels,
         }
       );
       break;
@@ -671,7 +671,7 @@ function deploy(functions, runtime, service, options) {
         verbose: false,
         log: console.log,
         contentType: ('contentType' in description) ? description.contentType : 'text',
-        labels: description.labels || {}
+        labels: description.labels || {},
       });
 
       const ns = description.namespace || opts.namespace;


### PR DESCRIPTION
Hello,
Currently labels specified in a function declaration in serverless.yml ([https://www.serverless.com/framework/docs/providers/kubeless/guide/functions#labels](https://www.serverless.com/framework/docs/providers/kubeless/guide/functions#labels)) are set to all the Kubernetes resources related to that function (pods, deployment, service and Function CRD) except for the function trigger CRD.
With this PR we set these labels also to the function trigger CRD.
