### PR TITLE
Add ability to set function deploy concurrency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '8'
+- '12'
 script:
 - npm run lint
 - npm test

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,9 +1,12 @@
 /*
  Copyright 2017 Bitnami.
+ 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
+ 
      http://www.apache.org/licenses/LICENSE-2.0
+ 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -646,53 +646,69 @@ function deployTrigger(event, funcName, namespace, service, options) {
 }
 
 function deploy(functions, runtime, service, options) {
-  const errors = [];
-  let counter = 0;
+  // Concurrents deploys to execute
+  const deployConcurrency = process.env.DEPLOY_CONCURRENCY || Number.MAX_VALUE;
 
-  // Total number of elements to deploy
-  const elements = helpers.getDeployableItemsNumber(functions);
-  return new BbPromise((resolve, reject) => {
-    _.each(functions, (description) => {
-      const opts = _.defaults({}, options, {
-        hostname: null,
-        namespace: 'default',
-        memorySize: null,
-        force: false,
-        verbose: false,
-        log: console.log,
-        contentType: ('contentType' in description) ? description.contentType : 'text',
-      });
+  return new BbPromise(async (deployResolve, deployReject) => {
+    const deployQueue = functions.slice();
+    while (deployQueue.length > 0) {
+      
+      let functionsToDeploy = deployQueue.splice(0, deployConcurrency);
 
-      const ns = description.namespace || opts.namespace;
-      if (description.handler) {
-        deployFunction(description, ns, runtime, opts.contentType, opts)
-          .catch(deploymentErr => errors.push(deploymentErr))
-          .then((res) => {
-            if (res.code && res.code !== 200) {
-              errors.push(res.message);
-            }
-            _.each(description.events, event => {
-              deployTrigger(event, description.id, ns, service, opts)
-                .catch(triggerErr => errors.push(triggerErr))
-                .then((tr) => {
-                  if (tr && tr.code && tr.code !== 200) {
-                    errors.push(tr.message);
+      try {
+        await new BbPromise((resolve, reject) => {
+          const errors = [];
+          let counter = 0;
+          // Total number of elements to deploy for this iteration
+          const elements = helpers.getDeployableItemsNumber(functionsToDeploy);
+          _.each(functionsToDeploy, (description) => {
+            const opts = _.defaults({}, options, {
+              hostname: null,
+              namespace: 'default',
+              memorySize: null,
+              force: false,
+              verbose: false,
+              log: console.log,
+              contentType: ('contentType' in description) ? description.contentType : 'text',
+            });
+
+            const ns = description.namespace || opts.namespace;
+            if (description.handler) {
+              deployFunction(description, ns, runtime, opts.contentType, opts)
+                .catch(deploymentErr => errors.push(deploymentErr))
+                .then((res) => {
+                  if (res.code && res.code !== 200) {
+                    errors.push(res.message);
                   }
+                  _.each(description.events, event => {
+                    deployTrigger(event, description.id, ns, service, opts)
+                      .catch(triggerErr => errors.push(triggerErr))
+                      .then((tr) => {
+                        if (tr && tr.code && tr.code !== 200) {
+                          errors.push(tr.message);
+                        }
+                        counter++;
+                        helpers.checkFinished(counter, elements, errors, resolve, reject);
+                      });
+                  });
                   counter++;
                   helpers.checkFinished(counter, elements, errors, resolve, reject);
                 });
-            });
-            counter++;
-            helpers.checkFinished(counter, elements, errors, resolve, reject);
+            } else {
+              counter++;
+              opts.log(
+                `Skipping deployment of ${description.id} since it doesn't have a handler`
+              );
+              helpers.checkFinished(counter, elements, errors, resolve, reject);
+            }
           });
-      } else {
-        counter++;
-        opts.log(
-          `Skipping deployment of ${description.id} since it doesn't have a handler`
-        );
-        helpers.checkFinished(counter, elements, errors, resolve, reject);
+        });
+      } catch(ex) {
+        deployReject(ex);
+        return;
       }
-    });
+    }
+    deployResolve();
   });
 }
 

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -649,66 +649,67 @@ function deploy(functions, runtime, service, options) {
   // Concurrents deploys to execute
   const deployConcurrency = process.env.DEPLOY_CONCURRENCY || Number.MAX_VALUE;
 
-  return new BbPromise(async (deployResolve, deployReject) => {
+  return new BbPromise((deployResolve, deployReject) => {
     const deployQueue = functions.slice();
-    while (deployQueue.length > 0) {
-      
-      let functionsToDeploy = deployQueue.splice(0, deployConcurrency);
 
-      try {
-        await new BbPromise((resolve, reject) => {
-          const errors = [];
-          let counter = 0;
-          // Total number of elements to deploy for this iteration
-          const elements = helpers.getDeployableItemsNumber(functionsToDeploy);
-          _.each(functionsToDeploy, (description) => {
-            const opts = _.defaults({}, options, {
-              hostname: null,
-              namespace: 'default',
-              memorySize: null,
-              force: false,
-              verbose: false,
-              log: console.log,
-              contentType: ('contentType' in description) ? description.contentType : 'text',
-            });
-
-            const ns = description.namespace || opts.namespace;
-            if (description.handler) {
-              deployFunction(description, ns, runtime, opts.contentType, opts)
-                .catch(deploymentErr => errors.push(deploymentErr))
-                .then((res) => {
-                  if (res.code && res.code !== 200) {
-                    errors.push(res.message);
-                  }
-                  _.each(description.events, event => {
-                    deployTrigger(event, description.id, ns, service, opts)
-                      .catch(triggerErr => errors.push(triggerErr))
-                      .then((tr) => {
-                        if (tr && tr.code && tr.code !== 200) {
-                          errors.push(tr.message);
-                        }
-                        counter++;
-                        helpers.checkFinished(counter, elements, errors, resolve, reject);
-                      });
-                  });
-                  counter++;
-                  helpers.checkFinished(counter, elements, errors, resolve, reject);
-                });
-            } else {
-              counter++;
-              opts.log(
-                `Skipping deployment of ${description.id} since it doesn't have a handler`
-              );
-              helpers.checkFinished(counter, elements, errors, resolve, reject);
-            }
-          });
+    const deployFunctions = (functionsToDeploy) => new BbPromise((resolve, reject) => {
+      const errors = [];
+      let counter = 0;
+      // Total number of elements to deploy for this iteration
+      const elements = helpers.getDeployableItemsNumber(functionsToDeploy);
+      _.each(functionsToDeploy, (description) => {
+        const opts = _.defaults({}, options, {
+          hostname: null,
+          namespace: 'default',
+          memorySize: null,
+          force: false,
+          verbose: false,
+          log: console.log,
+          contentType: ('contentType' in description) ? description.contentType : 'text',
         });
-      } catch(ex) {
-        deployReject(ex);
-        return;
+
+        const ns = description.namespace || opts.namespace;
+        if (description.handler) {
+          deployFunction(description, ns, runtime, opts.contentType, opts)
+            .catch(deploymentErr => errors.push(deploymentErr))
+            .then((res) => {
+              if (res.code && res.code !== 200) {
+                errors.push(res.message);
+              }
+              _.each(description.events, event => {
+                deployTrigger(event, description.id, ns, service, opts)
+                  .catch(triggerErr => errors.push(triggerErr))
+                  .then((tr) => {
+                    if (tr && tr.code && tr.code !== 200) {
+                      errors.push(tr.message);
+                    }
+                    counter++;
+                    helpers.checkFinished(counter, elements, errors, resolve, reject);
+                  });
+              });
+              counter++;
+              helpers.checkFinished(counter, elements, errors, resolve, reject);
+            });
+        } else {
+          counter++;
+          opts.log(
+            `Skipping deployment of ${description.id} since it doesn't have a handler`
+          );
+          helpers.checkFinished(counter, elements, errors, resolve, reject);
+        }
+      });
+    });
+
+    const nextDeploy = () => {
+      if (deployQueue.length > 0) {
+        const functionsToDeploy = deployQueue.splice(0, deployConcurrency);
+        deployFunctions(functionsToDeploy).then(() => nextDeploy()).catch((ex) => deployReject(ex));
+      } else {
+        deployResolve();
       }
-    }
-    deployResolve();
+    };
+
+    nextDeploy();
   });
 }
 

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,12 +1,12 @@
 /*
  Copyright 2017 Bitnami.
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
      http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
A deploy of a service with a lot of functions could results in an high cpu/ram/io pressure for a k8s infrastructure.
Think to a dotnet service with twenty function, for instance. When you deploy this service, kubeless creates twenty build pod at the same time.
With this pull request you can set an environment variable to deal with deploy concurrency.

As example:
```
export DEPLOY_CONCURRENCY=2
serverless deploy
```

The functions will be deployed two at a time.
