### PR TITLE
fix unable to run function in other namespaces

### DIFF
--- a/lib/invoke.js
+++ b/lib/invoke.js
@@ -80,7 +80,7 @@ function invoke(func, data, funcsDesc, options) {
   const namespace = desc.namespace ||
         opts.namespace ||
         helpers.getDefaultNamespace(config);
-  const connectionOptions = helpers.getConnectionOptions(helpers.loadKubeConfig());
+  const connectionOptions = helpers.getConnectionOptions(helpers.loadKubeConfig(), { namespace });
   const core = new Api.Core(connectionOptions);
   const requestData = getData(data, {
     path: opts.path,
@@ -112,7 +112,7 @@ function invoke(func, data, funcsDesc, options) {
         resolve(response);
       }
     };
-    core.services.get((err, servicesInfo) => {
+    core.ns.services.get((err, servicesInfo) => {
       if (err) {
         reject(err);
       } else {

--- a/lib/invoke.js
+++ b/lib/invoke.js
@@ -112,7 +112,7 @@ function invoke(func, data, funcsDesc, options) {
         resolve(response);
       }
     };
-    core.ns.services.get((err, servicesInfo) => {
+    core.services.get((err, servicesInfo) => {
       if (err) {
         reject(err);
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.12.0",
+  "version": "0.11.1",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/kubelessInvoke.test.js
+++ b/test/kubelessInvoke.test.js
@@ -234,7 +234,7 @@ describe('KubelessInvoke', () => {
           statusMessage: 'OK',
         });
       });
-      nocksvc(kubeApiURL, func, serverlessWithNS.service.functions[func].namespace);
+      nocksvc(kubeApiURL, func, serverlessWithNS.service.provider.namespace);
       return kubelessInvoke.invokeFunction().then((res) => {
         expect(res).to.be.eql({
           statusCode: 200,

--- a/test/kubelessInvoke.test.js
+++ b/test/kubelessInvoke.test.js
@@ -33,16 +33,16 @@ const serverless = require('./lib/serverless')({ service: { functions: { 'my-fun
 
 require('chai').use(chaiAsPromised);
 
-function nocksvc(url, funcs) {
+function nocksvc(url, funcs, namespace = 'default') {
   nock(url)
-    .get('/api/v1/namespaces/default/services')
+    .get(`/api/v1/namespaces/${namespace}/services`)
     .reply(200, {
       items: _.map(_.flatten([funcs]), f => ({
         metadata:
         {
           name: f,
           namespace: 'default',
-          selfLink: `/api/v1/namespaces/default/services/${f}`,
+          selfLink: `/api/v1/namespaces/${namespace}/services/${f}`,
           uid: '010a169d-618c-11e7-9939-080027abf356',
           resourceVersion: '248',
           creationTimestamp: '2017-07-05T14:12:39Z',
@@ -234,7 +234,7 @@ describe('KubelessInvoke', () => {
           statusMessage: 'OK',
         });
       });
-      nocksvc(kubeApiURL, func);
+      nocksvc(kubeApiURL, func, 'test');
       return kubelessInvoke.invokeFunction().then((res) => {
         expect(res).to.be.eql({
           statusCode: 200,
@@ -257,7 +257,7 @@ describe('KubelessInvoke', () => {
           statusMessage: 'OK',
         });
       });
-      nocksvc(kubeApiURL, func);
+      nocksvc(kubeApiURL, func, 'test');
       return kubelessInvoke.invokeFunction().then((res) => {
         expect(res).to.be.eql({
           statusCode: 200,

--- a/test/kubelessInvoke.test.js
+++ b/test/kubelessInvoke.test.js
@@ -234,7 +234,7 @@ describe('KubelessInvoke', () => {
           statusMessage: 'OK',
         });
       });
-      nocksvc(kubeApiURL, func, 'test');
+      nocksvc(kubeApiURL, func, serverlessWithNS.service.functions[func].namespace);
       return kubelessInvoke.invokeFunction().then((res) => {
         expect(res).to.be.eql({
           statusCode: 200,
@@ -257,7 +257,7 @@ describe('KubelessInvoke', () => {
           statusMessage: 'OK',
         });
       });
-      nocksvc(kubeApiURL, func, 'test');
+      nocksvc(kubeApiURL, func, serverlessWithNS.service.functions[func].namespace);
       return kubelessInvoke.invokeFunction().then((res) => {
         expect(res).to.be.eql({
           statusCode: 200,


### PR DESCRIPTION
I had this issue that I could invoke functions only in the `default` namespace, if I deploy in other namespaces it will fail to be invoked
I noticed that when you create a new serverless project with the command:
`serverless create --template kubeless-nodejs --path new-project` works fine, you can deploy in every namespace and can invoke the functions.
If you check in package.json it uses serverless-kubeless v0.4.0. I've tested and everything works fine up to version 0.6.0
In the new versions of serverless-kubeless it doesn't work. The only difference I found between versions was that in invoke.js on line 115 the function was changed from `core.services.get` => `core.ns.services.get`
If you remove `ns` it works fine again.