### PR TITLE
Move tolerations to PodTemplateSpec

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -192,7 +192,7 @@ function getFunctionDescription(
       funcs.spec.deployment.spec.template.spec.affinity = affinity;
     }
     if (tolerations) {
-      funcs.spec.deployment.spec.tolerations = tolerations;
+      funcs.spec.deployment.spec.template.spec.tolerations = tolerations;
     }
   }
   return funcs;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-kubeless",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "This plugin enables support for Kubeless within the [Serverless Framework](https://github.com/serverless).",
   "main": "index.js",
   "directories": {

--- a/test/kubelessDeploy.test.js
+++ b/test/kubelessDeploy.test.js
@@ -1143,9 +1143,9 @@ describe('KubelessDeploy', () => {
                 containers: [{
                   name: functionName,
                 }],
+                tolerations,
               },
             },
-            tolerations,
           },
         },
       }));
@@ -1178,9 +1178,9 @@ describe('KubelessDeploy', () => {
                 containers: [{
                   name: functionName,
                 }],
+                tolerations,
               },
             },
-            tolerations,
           },
         },
       }));


### PR DESCRIPTION
Right now the tolerations aren't included in the yaml of
the Pods created by the Deployment. Moving them into the
PodTemplateSpec is fixing this.