### PR TITLE
Better way to check when function pod is ready

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -199,7 +199,7 @@ function getFunctionDescription(
 }
 
 
-function waitForDeployment(funcName, requestMoment, namespace, options) {
+function waitForDeployment(funcName, requestMoment, namespace, oldPodTemplateHash, options) {
   const opts = _.defaults({}, options, {
     verbose: false,
     log: console.log,
@@ -234,9 +234,13 @@ function waitForDeployment(funcName, requestMoment, namespace, options) {
             (pod) => (
               !_.isEmpty(pod.metadata.labels) &&
               pod.metadata.labels.function === funcName &&
+              pod.status.reason !== 'Evicted' &&
+              pod.status.phase !== 'Succeeded' &&
+              pod.metadata.labels['pod-template-hash'] !== oldPodTemplateHash &&
               !pod.metadata.deletionTimestamp
             )
           );
+
           if (_.isEmpty(functionPods)) {
             retries++;
             opts.log(`Unable to find any running pod for ${funcName}. Retrying...`);
@@ -340,6 +344,7 @@ function deployFunctionAndWait(body, functions, options) {
           body.metadata.name,
           requestMoment,
           functions.namespace,
+          null,
           { verbose: opts.verbose, log: opts.log }
         ).catch((waitErr) => {
           reject(waitErr);
@@ -356,28 +361,83 @@ function redeployFunctionAndWait(body, functions, options) {
     verbose: false,
   });
   const requestMoment = moment().milliseconds(0);
+  opts.log(`Updating function ${body.metadata.name}...`);
   return new BbPromise((resolve, reject) => {
-    functions.put(body.metadata.name, { body }).catch((err) => reject(new Error(
-      `Unable to update the function ${body.metadata.name}. Received:\n` +
-      `  Code: ${err.code}\n` +
-      `  Message: ${err.message}`
-    ))).then((res) => {
-      if (res.code && res.code !== 200) {
-        reject(new Error(
-          `Unable to update the function ${body.metadata.name}. Received:\n` +
-          `  Code: ${res.code}\n` +
-          `  Message: ${res.message}`));
-      } else {
-        waitForDeployment(
-          body.metadata.name,
-          requestMoment,
-          functions.namespace,
-          { verbose: opts.verbose, log: opts.log }
-        ).then(() => {
-          resolve(true);
-        });
-      }
-    });
+    const updateFunction = (currentPodTemplateHash) => {
+      functions.put(body.metadata.name, { body }).catch((err) => reject(new Error(
+        `Unable to update the function ${body.metadata.name}. Received:\n` +
+        `  Code: ${err.code}\n` +
+        `  Message: ${err.message}`
+      ))).then((res) => {
+        if (res.code && res.code !== 200) {
+          reject(new Error(
+            `Unable to update the function ${body.metadata.name}. Received:\n` +
+            `  Code: ${res.code}\n` +
+            `  Message: ${res.message}`));
+        } else {
+          waitForDeployment(
+            body.metadata.name,
+            requestMoment,
+            functions.namespace,
+            currentPodTemplateHash,
+            { verbose: opts.verbose, log: opts.log }
+          ).then(() => {
+            resolve(true);
+          });
+        }
+      });
+    };
+    // get current deployment for the function
+    const kubeConfig = helpers.loadKubeConfig();
+    const apps = new Api.Apps(helpers.getConnectionOptions(
+      kubeConfig, { namespace: functions.namespace, version: 'v1' })
+    );
+    apps.ns.deployments.get(
+      { qs:
+        { labelSelector: `function=${body.metadata.name},created-by=kubeless` },
+      },
+      (deploymentsErr, deploymentsInfo) => {
+        if (deploymentsErr || _.isEmpty(deploymentsInfo.items)) {
+          // unable to get the current function deployment. Update anyway.
+          updateFunction();
+        } else {
+          const deployRev =
+            deploymentsInfo
+            .items[0]
+            .metadata
+            .annotations['deployment.kubernetes.io/revision'];
+          // get "current" replicaSet for the function
+          const rsApi = new Api.Extensions(helpers.getConnectionOptions(
+            kubeConfig, { namespace: functions.namespace, version: 'v1' })
+          );
+          // replicasets were in 'extensions' api group in older k8s version.
+          // k8s-client lib upgrade needed. Dirty hack for now.
+          rsApi.ns.replicasets.path = rsApi.ns.replicasets.path.replace(/\/extensions\//, '/apps/');
+          rsApi.ns.replicasets.get(
+            {
+              qs: {
+                labelSelector: `function=${body.metadata.name},created-by=kubeless`,
+              },
+            }, (rsErr, replicaSets) => {
+            if (rsErr) {
+              // unable to get the current function replicaSet. Update anyway.
+              updateFunction();
+            } else {
+              const currentReplicaSet = _.filter(replicaSets.items,
+                (replicaSet) => (
+                  replicaSet.metadata.annotations['deployment.kubernetes.io/revision'] === deployRev
+                )
+              );
+              if (_.isEmpty(currentReplicaSet)) {
+                // no replicaSet found. Update anyway.
+                updateFunction();
+              } else {
+                updateFunction(currentReplicaSet[0].metadata.labels['pod-template-hash']);
+              }
+            }
+          });
+        }
+      });
   });
 }
 


### PR DESCRIPTION
The current logic to check if a pod for a deployed function is running fails in these situations:

- a previously deployed pod is running
- an evicted pod is present
- a succeded cronjob pod is present

This pull request fixes these situations by checking the correct pod revision for the "current" replicaSet and by filtering evicted/succeded pods